### PR TITLE
Add deregister_group IPC for worker lifecycle cleanup

### DIFF
--- a/apps/nanoclaw/src/db.ts
+++ b/apps/nanoclaw/src/db.ts
@@ -657,6 +657,13 @@ export function setRegisteredGroup(jid: string, group: RegisteredGroup): void {
   );
 }
 
+export function deleteRegisteredGroup(jid: string): boolean {
+  const result = db.prepare(
+    `DELETE FROM registered_groups WHERE jid = ?`,
+  ).run(jid);
+  return result.changes > 0;
+}
+
 export function getAllRegisteredGroups(): Record<string, RegisteredGroup> {
   const rows = db.prepare('SELECT * FROM registered_groups').all() as Array<{
     jid: string;

--- a/apps/nanoclaw/src/ipc.ts
+++ b/apps/nanoclaw/src/ipc.ts
@@ -5,7 +5,7 @@ import { CronExpressionParser } from 'cron-parser';
 
 import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
 import { AvailableGroup } from './container-runner.js';
-import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
+import { createTask, deleteTask, deleteRegisteredGroup, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
 import { logger } from './logger.js';
 import { RegisteredGroup } from './types.js';
@@ -462,6 +462,56 @@ export async function processTaskIpc(
       }
       break;
 
+
+    case 'deregister_group':
+      // Only main group can deregister groups
+      if (!isMain) {
+        logger.warn(
+          { sourceGroup },
+          'Unauthorized deregister_group attempt blocked',
+        );
+        break;
+      }
+      if (data.jid) {
+        const targetGroup = registeredGroups[data.jid];
+        if (!targetGroup) {
+          logger.warn(
+            { jid: data.jid },
+            'Cannot deregister: group not found',
+          );
+          break;
+        }
+        // Safety: never allow deregistering the main group
+        if (targetGroup.isMain) {
+          logger.warn(
+            { jid: data.jid },
+            'Cannot deregister main group',
+          );
+          break;
+        }
+        const deleted = deleteRegisteredGroup(data.jid);
+        if (deleted) {
+          // Clean up group folder (IPC dir, session data)
+          const groupDir = path.join(DATA_DIR, 'groups', targetGroup.folder);
+          const ipcDir = path.join(DATA_DIR, 'ipc', targetGroup.folder);
+          try {
+            if (fs.existsSync(ipcDir)) fs.rmSync(ipcDir, { recursive: true });
+            // Keep group folder for session history (logs, CLAUDE.md)
+            // but remove IPC dir to prevent stale message processing
+          } catch (err) {
+            logger.error({ err, folder: targetGroup.folder }, 'Error cleaning up deregistered group');
+          }
+          // Refresh in-memory groups
+          await deps.syncGroups(true);
+          logger.info(
+            { jid: data.jid, folder: targetGroup.folder, sourceGroup },
+            'Group deregistered via IPC',
+          );
+        }
+      } else {
+        logger.warn({ data }, 'Invalid deregister_group request - missing jid');
+      }
+      break;
     default:
       logger.warn({ type: data.type }, 'Unknown IPC task type');
   }


### PR DESCRIPTION
## Summary
- Adds `deleteRegisteredGroup()` to `db.ts` (SQLite DELETE)
- Adds `deregister_group` IPC case to `ipc.ts` (main-group-only)
- Enables Architect to clean up worker groups after task completion

## Worker Lifecycle (complete flow with PRs #7 + #8 + this)
```
Architect registers group (register_group IPC, with envVars)
  → Architect sends task to group's Discord channel (bot message, PR #7)
  → NanoClaw spawns container with AGENT_ROLE/AGENT_SCOPE (envVars, PR #8)
  → Worker executes task, creates PR
  → Architect deregisters group (deregister_group IPC, this PR)
```

## Safety
- Main-group-only (non-main attempts blocked)
- Cannot deregister the main group itself
- IPC directory cleaned up (prevents stale message processing)
- Group folder kept (session history for debugging)

## Governance
**Tier 2** — non-behavioral code change. Adds IPC operation following existing `register_group` pattern.

## Test plan
- [ ] Main group sends `deregister_group` → group removed from SQLite, IPC dir cleaned
- [ ] Non-main group sends `deregister_group` → blocked with warning
- [ ] Attempt to deregister main group → blocked with warning
- [ ] Deregister non-existent group → warning logged, no crash
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)