### PR TITLE
Add notification relay IPC type for worker notifications

### DIFF
--- a/apps/nanoclaw/src/config.ts
+++ b/apps/nanoclaw/src/config.ts
@@ -81,6 +81,15 @@ export function getTriggerPattern(trigger?: string): RegExp {
 
 export const TRIGGER_PATTERN = buildTriggerPattern(DEFAULT_TRIGGER);
 
+// Notification channels that any group can post to (bypasses normal message authorization).
+// Workers write { type: 'notification', channel: '<key>', text: '...' } to their IPC dir.
+export const NOTIFICATION_CHANNELS: Record<string, string> = {
+  'main-ops': process.env.DISCORD_CHANNEL_MAIN_OPS || '',
+  'workbench-ops': process.env.DISCORD_CHANNEL_WORKBENCH_OPS || '',
+  'alerts': process.env.DISCORD_CHANNEL_ALERTS || '',
+  'workers': process.env.DISCORD_CHANNEL_WORKERS || '',
+};
+
 // Timezone for scheduled tasks, message formatting, etc.
 // Validates each candidate is a real IANA identifier before accepting.
 function resolveConfigTimezone(): string {

--- a/apps/nanoclaw/src/ipc.ts
+++ b/apps/nanoclaw/src/ipc.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { CronExpressionParser } from 'cron-parser';
 
-import { DATA_DIR, IPC_POLL_INTERVAL, TIMEZONE } from './config.js';
+import { DATA_DIR, IPC_POLL_INTERVAL, NOTIFICATION_CHANNELS, TIMEZONE } from './config.js';
 import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, deleteRegisteredGroup, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder } from './group-folder.js';
@@ -90,6 +90,23 @@ export function startIpcWatcher(deps: IpcDeps): void {
                   logger.warn(
                     { chatJid: data.chatJid, sourceGroup },
                     'Unauthorized IPC message attempt blocked',
+                  );
+                }
+              } else if (data.type === 'notification' && data.channel && data.text) {
+                // Notifications bypass normal message authorization.
+                // Any group can post notifications to predefined channels.
+                const channelJid = NOTIFICATION_CHANNELS[data.channel];
+                if (channelJid) {
+                  const prefix = data.priority === 'urgent' ? '\u{1f6a8} ' : '';
+                  await deps.sendMessage(channelJid, `${prefix}${data.text}`);
+                  logger.info(
+                    { channel: data.channel, sourceGroup, priority: data.priority },
+                    'IPC notification sent',
+                  );
+                } else {
+                  logger.warn(
+                    { channel: data.channel, sourceGroup },
+                    'Unknown notification channel',
                   );
                 }
               }


### PR DESCRIPTION
## Summary
- Adds `NOTIFICATION_CHANNELS` mapping in `config.ts` — maps channel names (`main-ops`, `workbench-ops`, `alerts`, `workers`) to Discord JIDs via env vars
- Adds `notification` IPC type handler in `ipc.ts` — any group can post to predefined notification channels without normal message authorization
- Urgent notifications (priority: `urgent`) get a siren emoji prefix

## How it works
Workers write JSON files to their `ipc/{folder}/messages/` directory:
```json
{
  "type": "notification",
  "channel": "workbench-ops",
  "text": "[EXECUTOR] PR #80 created",
  "priority": "normal"
}
```

The IPC watcher picks them up, resolves the channel JID from `NOTIFICATION_CHANNELS`, and sends via `deps.sendMessage`. Files are cleaned up after processing (same as existing message type).

## Files changed
- `apps/nanoclaw/src/config.ts` — added `NOTIFICATION_CHANNELS` export
- `apps/nanoclaw/src/ipc.ts` — added import + `else if` notification handler in message processing loop

## Test plan
- [ ] Set `DISCORD_CHANNEL_WORKBENCH_OPS` env var and write a notification JSON to an IPC dir — verify message appears in channel
- [ ] Write notification with unknown channel name — verify warning logged, no crash
- [ ] Write notification with `priority: "urgent"` — verify siren prefix
- [ ] Verify existing `message` type IPC still works unchanged
- [ ] Verify `fs.unlinkSync` runs for both message and notification types

🤖 Generated with [Claude Code](https://claude.com/claude-code)