### PR TITLE
Add worker status relay + stale heartbeat detection

### DIFF
--- a/apps/nanoclaw/src/ipc.ts
+++ b/apps/nanoclaw/src/ipc.ts
@@ -162,6 +162,79 @@ export function startIpcWatcher(deps: IpcDeps): void {
       } catch (err) {
         logger.error({ err, sourceGroup }, 'Error reading IPC tasks directory');
       }
+      // Process status from this group's IPC directory (heartbeat, completion, failure)
+      const statusDir = path.join(ipcBaseDir, sourceGroup, 'status');
+      try {
+        if (fs.existsSync(statusDir)) {
+          const statusFiles = fs
+            .readdirSync(statusDir)
+            .filter((f) => f.endsWith('.json'));
+          for (const file of statusFiles) {
+            const filePath = path.join(statusDir, file);
+            try {
+              const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+              // Relay status to main group's worker-status directory
+              const mainFolder = [...folderIsMain.entries()].find(([, v]) => v)?.[0];
+              if (mainFolder) {
+                const workerStatusDir = path.join(ipcBaseDir, mainFolder, 'worker-status');
+                fs.mkdirSync(workerStatusDir, { recursive: true });
+                fs.writeFileSync(
+                  path.join(workerStatusDir, `${sourceGroup}.json`),
+                  JSON.stringify(
+                    { ...data, workerGroup: sourceGroup, relayedAt: new Date().toISOString() },
+                    null,
+                    2,
+                  ),
+                );
+                logger.debug(
+                  { sourceGroup, type: data.type },
+                  'Worker status relayed to main group',
+                );
+              }
+              fs.unlinkSync(filePath);
+            } catch (err) {
+              logger.error(
+                { file, sourceGroup, err },
+                'Error processing IPC status',
+              );
+              const errorDir = path.join(ipcBaseDir, 'errors');
+              fs.mkdirSync(errorDir, { recursive: true });
+              fs.renameSync(
+                filePath,
+                path.join(errorDir, `${sourceGroup}-status-${file}`),
+              );
+            }
+          }
+        }
+      } catch (err) {
+        logger.error({ err, sourceGroup }, 'Error reading IPC status directory');
+      }
+    }
+
+    // Stale heartbeat detection: check all relayed worker statuses
+    const mainFolderForStale = [...folderIsMain.entries()].find(([, v]) => v)?.[0];
+    if (mainFolderForStale) {
+      const workerStatusDir = path.join(ipcBaseDir, mainFolderForStale, 'worker-status');
+      if (fs.existsSync(workerStatusDir)) {
+        for (const entry of fs.readdirSync(workerStatusDir).filter((f) => f.endsWith('.json'))) {
+          try {
+            const statusPath = path.join(workerStatusDir, entry);
+            const statusData = JSON.parse(fs.readFileSync(statusPath, 'utf-8'));
+            if (statusData.type === 'heartbeat' && statusData.timestamp && !statusData.stale) {
+              const ageMs = Date.now() - new Date(statusData.timestamp).getTime();
+              if (ageMs > 10 * 60 * 1000) {
+                statusData.stale = true;
+                statusData.staleDetectedAt = new Date().toISOString();
+                fs.writeFileSync(statusPath, JSON.stringify(statusData, null, 2));
+                logger.warn(
+                  { workerGroup: statusData.workerGroup, ageMinutes: Math.round(ageMs / 60000) },
+                  'Stale worker heartbeat detected',
+                );
+              }
+            }
+          } catch { /* skip malformed entries */ }
+        }
+      }
     }
 
     setTimeout(processIpcFiles, IPC_POLL_INTERVAL);


### PR DESCRIPTION
## Summary
- Workers write status files (heartbeat/completion/failure) to `ipc/{folder}/status/`
- Host process relays to Architect at `ipc/{mainFolder}/worker-status/{worker}.json`
- Stale heartbeat detection flags workers with no heartbeat for 10+ minutes

## How It Works
```
Worker container          NanoClaw Host              Architect container
     │                         │                          │
     ├── writes heartbeat ──>  │                          │
     │   status/hb.json        │                          │
     │                         ├── reads + relays ──────> │
     │                         │   worker-status/wk.json  │
     │                         │                          │ reads status
     │                         ├── stale check ───────>   │ detects dead workers
     │                         │   (10 min threshold)     │
```

## Status Types
- **heartbeat**: `{ type, timestamp, status, currentAction, iteration }`
- **completion**: `{ type, status:"success", prUrl, summary, changedFiles }`
- **failure**: `{ type, error, iteration, sameErrorCount }`

## Governance
**Tier 2** — non-behavioral. Follows existing IPC processing pattern (messages/, tasks/).

## Test plan
- [ ] Worker writes heartbeat → appears in Architect's worker-status/
- [ ] Worker writes completion → relayed with workerGroup + relayedAt fields
- [ ] No heartbeat for 10 min → stale flag set on status entry
- [ ] Malformed status files → moved to errors/ dir
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)