### PR TITLE
feat(digital-twin): add version field to health endpoint response

### DIFF
--- a/apps/digital-twin/src/routes/health.ts
+++ b/apps/digital-twin/src/routes/health.ts
@@ -2,6 +2,6 @@ import type { FastifyInstance } from 'fastify';
 
 export default async function healthRoutes(fastify: FastifyInstance) {
   fastify.get('/api/health', async (_request, _reply) => {
-    return { status: 'ok', service: 'digital-twin' };
+    return { status: 'ok', service: 'digital-twin', version: '1.1.0' };
   });
 }


### PR DESCRIPTION
## Summary
- Adds `version: "1.1.0"` to the Digital Twin `/api/health` endpoint JSON response

## Change
\`\`\`diff
- return { status: 'ok', service: 'digital-twin' };
+ return { status: 'ok', service: 'digital-twin', version: '1.1.0' };
\`\`\`

## Verify
\`\`\`bash
curl https://limitless-digital-twin.onrender.com/api/health
# Expected: {"status":"ok","service":"digital-twin","version":"1.1.0"}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)