### PR TITLE
feat(digital-twin): add startedAt field to health endpoint response

### DIFF
--- a/apps/digital-twin/src/routes/health.ts
+++ b/apps/digital-twin/src/routes/health.ts
@@ -2,6 +2,6 @@ import type { FastifyInstance } from 'fastify';
 
 export default async function healthRoutes(fastify: FastifyInstance) {
   fastify.get('/api/health', async (_request, _reply) => {
-    return { status: 'ok', service: 'digital-twin', version: '1.1.0' };
+    return { status: 'ok', service: 'digital-twin', version: '1.1.0', startedAt: new Date().toISOString() };
   });
 }


### PR DESCRIPTION
## Summary
- Adds `startedAt: new Date().toISOString()` to the Digital Twin `/api/health` endpoint JSON response
- Returns the current server timestamp with each health check
- Preserves existing `version: '1.1.0'` field from PR #14

## Change
```diff
- return { status: 'ok', service: 'digital-twin', version: '1.1.0' };
+ return { status: 'ok', service: 'digital-twin', version: '1.1.0', startedAt: new Date().toISOString() };
```

## Verify
```bash
curl https://limitless-digital-twin.onrender.com/api/health
# Expected: includes "startedAt": "2026-...T...Z"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)