### PR TITLE
feat(digital-twin): add homepage field to package.json

### DIFF
--- a/apps/digital-twin/package.json
+++ b/apps/digital-twin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "limitless-digital-twin",
   "version": "0.1.0",
+  "homepage": "https://limitless-longevity.health",
   "type": "module",
   "private": true,
   "engines": {


### PR DESCRIPTION
## Summary
- Adds `"homepage": "https://limitless-longevity.health"` as a top-level field in `apps/digital-twin/package.json`

## Change
```diff
+  "homepage": "https://limitless-longevity.health",
```

## Verify
```bash
cat apps/digital-twin/package.json | grep homepage
# Expected: "homepage": "https://limitless-longevity.health"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)