### PR TITLE
test: verify native GH_TOKEN credential fix

### DIFF
--- a/apps/digital-twin/HEALTHCHECK.md
+++ b/apps/digital-twin/HEALTHCHECK.md
@@ -1,0 +1,3 @@
+# HEALTHCHECK
+
+<!-- verified: credential fix applied 2026-04-03 -->


### PR DESCRIPTION
## Summary
Verification PR — confirms that `GH_TOKEN` is now natively available in subagent bash shells without any workaround file.

## What changed
Appended a comment to `apps/digital-twin/HEALTHCHECK.md`.

## Credential method
Native `$GH_TOKEN` from environment — no `.agent-credentials.env` relay used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)