### PR TITLE
Fix lesson completion redirect: add basePath to navigation URLs

### DIFF
--- a/apps/paths/src/app/(frontend)/courses/[slug]/lessons/[lessonSlug]/page.tsx
+++ b/apps/paths/src/app/(frontend)/courses/[slug]/lessons/[lessonSlug]/page.tsx
@@ -69,8 +69,9 @@ export default async function LessonPage({ params: paramsPromise }: Args) {
   if (currentIndex === -1) return notFound()
 
   lesson = { ...allLessons[currentIndex].lesson, _moduleIndex: allLessons[currentIndex].mi, _lessonIndex: allLessons[currentIndex].li }
-  if (currentIndex > 0) prevHref = `/courses/${slug}/lessons/${allLessons[currentIndex - 1].lesson.slug}`
-  if (currentIndex < allLessons.length - 1) nextHref = `/courses/${slug}/lessons/${allLessons[currentIndex + 1].lesson.slug}`
+  const base = process.env.NEXT_PUBLIC_BASE_PATH || ''
+  if (currentIndex > 0) prevHref = `${base}/courses/${slug}/lessons/${allLessons[currentIndex - 1].lesson.slug}`
+  if (currentIndex < allLessons.length - 1) nextHref = `${base}/courses/${slug}/lessons/${allLessons[currentIndex + 1].lesson.slug}`
 
   // Fetch lesson progress
   const progressResult = await payload.find({


### PR DESCRIPTION
## Problem
Lesson completion navigates to \`/courses/...\` instead of \`/learn/courses/...\`, causing a 404. \`prevHref\` and \`nextHref\` were built without the \`/learn\` basePath.

## Fix
Prepend \`process.env.NEXT_PUBLIC_BASE_PATH || ''\` to both navigation URLs in \`apps/paths/src/app/(frontend)/courses/[slug]/lessons/[lessonSlug]/page.tsx\`.

## Verification
- \`cd apps/paths && pnpm build\` passes
- After deploy: marking a lesson complete navigates to next lesson, not 404

Fixes: HANDOFF-0401-Q

🤖 Generated with [Claude Code](https://claude.com/claude-code)