### PR TITLE
Switch AI to gpt-4o-mini and improve tutor loading UX

### DIFF
--- a/apps/paths/public/favicon.svg
+++ b/apps/paths/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="6" fill="#0a0a0a"/>
-  <text x="8" y="24" font-family="system-ui, sans-serif" font-size="22" font-weight="700" fill="#c8a55a" letter-spacing="0.05em">L</text>
+  <rect width="32" height="32" rx="4" fill="#0a0a0a"/>
+  <text x="8" y="24" font-family="Georgia, serif" font-size="22" font-weight="bold" fill="#C9A84C">L</text>
 </svg>


### PR DESCRIPTION
## Summary
Fixes AI tutor timeout issues (Cloudflare 100s limit) and improves loading UX.

## Changes

### Task 1 — Model switch (`src/ai/models.ts`)
- Replaced `nvidia/nemotron-nano-9b-v2:free` with `openai/gpt-4o-mini` across all 5 registry entries (tutor, quizGeneration, discover, actionPlan, dailyProtocol)

### Task 2 — Tutor loading UX (`src/components/TutorPanel/index.tsx`)
- Added visible "Thinking..." text alongside pulse cursor during loading
- Added 30s AbortController timeout on fetch
- On timeout: shows "The AI tutor is taking too long. Please try again."

### Task 3 — Favicon (`public/favicon.svg`)
- Created gold "L" on dark background — fixes 404 on every page load

## Verify
```bash
cd apps/paths && pnpm build  # must pass
```
After deploy: AI tutor responds faster, timeout shows friendly error, no more favicon 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)