### PR TITLE
feat(cubes): add GET /api/v1/health endpoint

### DIFF
--- a/apps/cubes/src/app/api/v1/health/route.ts
+++ b/apps/cubes/src/app/api/v1/health/route.ts
@@ -1,0 +1,10 @@
+/**
+ * GET /api/v1/health — Health check endpoint for monitoring (no auth required)
+ */
+export async function GET() {
+  return Response.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    environment: process.env.NODE_ENV,
+  })
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/health` at `apps/cubes/src/app/api/v1/health/route.ts`
- Returns `{ status: "ok", timestamp: <ISO string>, environment: <NODE_ENV> }`
- No auth required — safe for uptime monitoring probes
- Build verified ✓

## Test plan
- [ ] `curl https://<host>/api/v1/health` returns 200 with expected JSON shape
- [ ] Verify `timestamp` is a valid ISO 8601 string
- [ ] Verify `environment` reflects the deployment environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)