### PR TITLE
feat(digital-twin): add version and uptime to health endpoint

### DIFF
--- a/apps/digital-twin/src/routes/health.ts
+++ b/apps/digital-twin/src/routes/health.ts
@@ -1,7 +1,16 @@
 import type { FastifyInstance } from 'fastify';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../../package.json') as { version: string };
 
 export default async function healthRoutes(fastify: FastifyInstance) {
   fastify.get('/api/health', async (_request, _reply) => {
-    return { status: 'ok', service: 'digital-twin', version: '1.1.0' };
+    return {
+      status: 'ok',
+      service: 'digital-twin',
+      version: pkg.version,
+      uptime: Math.floor(process.uptime()),
+    };
   });
 }


### PR DESCRIPTION
## Summary

- Added `version` field to `/api/health` — read from `package.json` at runtime via `createRequire`
- Added `uptime` field — `Math.floor(process.uptime())` in whole seconds
- Existing fields (`status`, `service`) unchanged

## Test plan

- [ ] `pnpm build` passes (verified locally)
- [ ] `GET /api/health` returns `{ status, service, version, uptime }` with correct values
- [ ] `version` matches the value in `package.json`
- [ ] `uptime` increases on successive calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)