### PR TITLE
fix(infra): set HOSTNAME=0.0.0.0 on Cubes+ to fix Render port-scan timeout

### DIFF
--- a/infra/cubes.tf
+++ b/infra/cubes.tf
@@ -66,6 +66,13 @@ resource "render_web_service" "cubes" {
     NODE_ENV = {
       value = "production"
     }
+    # Bind to all interfaces — Next.js 16 standalone server.js reads HOSTNAME and binds
+    # to it; Render/Kubernetes injects HOSTNAME as the pod name, so without this override
+    # the service listens on the pod hostname rather than 0.0.0.0 and Render's port
+    # scanner never detects port 10000, causing a 14-minute timeout and rollback.
+    HOSTNAME = {
+      value = "0.0.0.0"
+    }
 
     # Gateway basePath
     NEXT_PUBLIC_BASE_PATH = {


### PR DESCRIPTION
## Root cause

Next.js 16 standalone `server.js` reads `process.env.HOSTNAME` and binds to it. Render/Kubernetes injects `HOSTNAME` as the pod name (e.g. `srv-d75rst9r0fns73f9qt70-6ff7d95d46-h8fdc`). The service listens on port 10000 but bound to the pod hostname — Render's external port scanner checks `0.0.0.0:10000`, never detects the open port, waits 14 minutes, and rolls back.

Every Cubes+ deploy since `cbddb39e` (2026-04-03, the Phase 0 monorepo sync) has failed this way. The migration changed the start command to use Next.js standalone output, exposing this `HOSTNAME` behaviour that didn't exist pre-migration.

**Evidence from 2026-04-11 08:04 deploy log:**
```
08:24:53  - Network: http://srv-d75rst9r0fns73f9qt70-6ff7d95d46-h8fdc:10000   ← bound to pod hostname
08:24:53  ✓ Ready in 0ms
08:38:48  ==> Timed Out                                                        ← Render rollback
08:38:50  ==> Detected service running on port 10000                           ← too late
```

## Fix

Add `HOSTNAME = { value = "0.0.0.0" }` to the Cubes+ Render service `env_vars` block in `infra/cubes.tf`.

## Why env var over inline start command

Option B would be `HOSTNAME=0.0.0.0 node .next/standalone/apps/cubes/server.js` in the `start_command`. The env var approach is preferred because:
- Separation of concerns — the start command already has Prisma migration prepended; inlining another variable increases coupling
- Reusability — if the start command is ever edited (e.g. to add health check warmup), the bind address fix survives automatically
- Consistency — other Next.js services in the monorepo (PATHS, Digital Twin) will need the same fix; env var is the obvious pattern to replicate

## ⚠️ DO NOT apply terraform

Human operator will apply. This PR is for review only. Operator will pull `terraform.tfvars` locally, run `terraform plan`, inspect output, and apply only after confirming the plan shows only the expected env var addition on `render_web_service.cubes`.

After any `terraform apply`, run `./scripts/restore-custom-domains.sh` as per standard procedure.

## References

- LIMITLESS Director session 2026-04-11
- Regression introduced: commit `cbddb39e` (Phase 0 monorepo sync, 2026-04-03)
- Confirmed stale since: `1ef22610` (2026-04-02, last successful deploy)