### PR TITLE
feat(nanoclaw): exclusive workspace mode for multi-repo Architect containers

### DIFF
--- a/apps/nanoclaw/src/config.ts
+++ b/apps/nanoclaw/src/config.ts
@@ -88,6 +88,9 @@ export const MONOREPO_PATH = process.env.LIMITLESS_MONOREPO_PATH || '';
 // Worktree base directory (worktrees created here, mounted into worker containers)
 export const WORKTREE_BASE = process.env.LIMITLESS_WORKTREE_BASE || '/tmp/nanoclaw-worktrees';
 
+// Base directory for on-the-fly external repo clones (exclusive workspace mode)
+export const EXT_REPOS_BASE = process.env.NANOCLAW_EXT_REPOS_BASE || '/tmp/nanoclaw-ext-repos';
+
 // Notification channels that any group can post to (bypasses normal message authorization).
 // Workers write { type: 'notification', channel: '<key>', text: '...' } to their IPC dir.
 export const NOTIFICATION_CHANNELS: Record<string, string> = {

--- a/apps/nanoclaw/src/container-runner.test.ts
+++ b/apps/nanoclaw/src/container-runner.test.ts
@@ -16,6 +16,16 @@ vi.mock('./config.js', () => ({
   IDLE_TIMEOUT: 1800000, // 30min
   ONECLI_URL: 'http://localhost:10254',
   TIMEZONE: 'America/Los_Angeles',
+  MONOREPO_PATH: '',
+  WORKTREE_BASE: '/tmp/nanoclaw-test-worktrees',
+  EXT_REPOS_BASE: '/tmp/nanoclaw-test-ext-repos',
+}));
+
+// Mock workspace-config — default to monorepo mode (no workspace.json)
+vi.mock('./workspace-config.js', () => ({
+  loadWorkspaceConfig: vi.fn(() => null),
+  cloneExternalRepo: vi.fn(async () => '/tmp/nanoclaw-test-ext-repos/test-repo-123'),
+  isExclusive: vi.fn((c: unknown) => (c as { mode?: string } | null)?.mode === 'exclusive'),
 }));
 
 // Mock logger
@@ -225,5 +235,191 @@ describe('container-runner timeout behavior', () => {
     const result = await resultPromise;
     expect(result.status).toBe('success');
     expect(result.newSessionId).toBe('session-456');
+  });
+});
+
+// ─── Workspace mode — mount configuration ────────────────────────────────────
+
+import { spawn } from 'child_process';
+import { loadWorkspaceConfig, cloneExternalRepo, isExclusive } from './workspace-config.js';
+
+/**
+ * Helper: run a container and capture the args passed to spawn().
+ * Returns immediately after spawn is called (before container output).
+ */
+async function captureSpawnArgs(
+  group: RegisteredGroup,
+  isMainFlag: boolean,
+): Promise<string[]> {
+  const mockSpawnFn = vi.mocked(spawn);
+  const resultPromise = runContainerAgent(
+    group,
+    { ...testInput, isMain: isMainFlag },
+    () => {},
+  );
+
+  // Give async setup (loadWorkspaceConfig / cloneExternalRepo) time to run
+  await vi.advanceTimersByTimeAsync(5);
+
+  // Emit output + close so the promise resolves
+  emitOutputMarker(fakeProc, { status: 'success', result: 'ok' });
+  await vi.advanceTimersByTimeAsync(5);
+  fakeProc.emit('close', 0);
+  await vi.advanceTimersByTimeAsync(5);
+  await resultPromise;
+
+  // Return the args array passed to spawn (second call arg)
+  const calls = mockSpawnFn.mock.calls;
+  const lastCall = calls[calls.length - 1];
+  return lastCall[1] as string[];
+}
+
+describe('workspace mode — monorepo (no workspace.json)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+    // Default: no workspace.json → monorepo mode
+    vi.mocked(loadWorkspaceConfig).mockReturnValue(null);
+    vi.mocked(isExclusive).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('does not mount /workspace/extra/repo for monorepo mode', async () => {
+    const args = await captureSpawnArgs(testGroup, false);
+    const argsStr = args.join(' ');
+    expect(argsStr).not.toContain('/workspace/extra/repo');
+  });
+
+  it('does not call cloneExternalRepo for monorepo mode', async () => {
+    await captureSpawnArgs(testGroup, false);
+    expect(cloneExternalRepo).not.toHaveBeenCalled();
+  });
+});
+
+describe('workspace mode — exclusive', () => {
+  const FAKE_TOKEN = 'ghp_fake_exclusive_token_xyz';
+  const FAKE_CLONE_DIR = '/tmp/nanoclaw-test-ext-repos/org-mythos-123';
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+
+    // Exclusive workspace config
+    vi.mocked(loadWorkspaceConfig).mockReturnValue({
+      mode: 'exclusive',
+      repo: 'org/mythos',
+      branch: 'main',
+      tokenEnvVar: 'GH_PAT_TOKEN_MYTHOS',
+    });
+    vi.mocked(isExclusive).mockReturnValue(true);
+    vi.mocked(cloneExternalRepo).mockResolvedValue(FAKE_CLONE_DIR);
+
+    // Inject the token into the process environment for this test
+    process.env.GH_PAT_TOKEN_MYTHOS = FAKE_TOKEN;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    delete process.env.GH_PAT_TOKEN_MYTHOS;
+  });
+
+  it('mounts the cloned repo at /workspace/extra/repo', async () => {
+    const args = await captureSpawnArgs(testGroup, false);
+    const argsStr = args.join(' ');
+    expect(argsStr).toContain(`${FAKE_CLONE_DIR}:/workspace/extra/repo`);
+  });
+
+  it('does NOT mount /workspace/extra/monorepo in exclusive mode', async () => {
+    const args = await captureSpawnArgs(testGroup, false);
+    const argsStr = args.join(' ');
+    expect(argsStr).not.toContain('/workspace/extra/monorepo');
+  });
+
+  it('injects the exclusive token as GH_TOKEN, not the host GH_TOKEN', async () => {
+    // Set a different host GH_TOKEN to ensure exclusive token takes precedence
+    const originalHostToken = process.env.GH_TOKEN;
+    process.env.GH_TOKEN = 'ghp_host_token_should_not_appear';
+
+    const args = await captureSpawnArgs(testGroup, false);
+    const argsStr = args.join(' ');
+
+    expect(argsStr).toContain(`GH_TOKEN=${FAKE_TOKEN}`);
+    expect(argsStr).not.toContain('ghp_host_token_should_not_appear');
+
+    process.env.GH_TOKEN = originalHostToken;
+  });
+
+  it('calls cloneExternalRepo with the correct repo and branch', async () => {
+    await captureSpawnArgs(testGroup, false);
+    expect(cloneExternalRepo).toHaveBeenCalledWith(
+      'org/mythos',
+      'main',
+      FAKE_TOKEN,
+      expect.any(String),
+    );
+  });
+
+  it('returns error when tokenEnvVar is not set on host', async () => {
+    delete process.env.GH_PAT_TOKEN_MYTHOS;
+
+    const result = await runContainerAgent(
+      testGroup,
+      { ...testInput, isMain: false },
+      () => {},
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('GH_PAT_TOKEN_MYTHOS');
+    expect(cloneExternalRepo).not.toHaveBeenCalled();
+  });
+
+  it('returns error when cloneExternalRepo fails', async () => {
+    vi.mocked(cloneExternalRepo).mockRejectedValue(
+      new Error('git clone failed: 128'),
+    );
+
+    const result = await runContainerAgent(
+      testGroup,
+      { ...testInput, isMain: false },
+      () => {},
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('Failed to clone');
+  });
+});
+
+describe('workspace mode — exclusive does not apply to main group', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+    // Even if workspace.json exists with exclusive mode, main containers skip it
+    vi.mocked(loadWorkspaceConfig).mockReturnValue({
+      mode: 'exclusive',
+      repo: 'org/mythos',
+      branch: 'main',
+      tokenEnvVar: 'GH_PAT_TOKEN_MYTHOS',
+    });
+    vi.mocked(isExclusive).mockReturnValue(true);
+    process.env.GH_PAT_TOKEN_MYTHOS = 'ghp_some_token';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    delete process.env.GH_PAT_TOKEN_MYTHOS;
+  });
+
+  it('does not clone or mount /workspace/extra/repo for the main group', async () => {
+    const args = await captureSpawnArgs(testGroup, true);
+    const argsStr = args.join(' ');
+    // Main group: workspace config not read → no ext repo mount
+    expect(argsStr).not.toContain('/workspace/extra/repo');
+    expect(cloneExternalRepo).not.toHaveBeenCalled();
   });
 });

--- a/apps/nanoclaw/src/container-runner.ts
+++ b/apps/nanoclaw/src/container-runner.ts
@@ -29,6 +29,12 @@ import {
 import { OneCLI } from '@onecli-sh/sdk';
 import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
+import {
+  ExclusiveWorkspaceConfig,
+  cloneExternalRepo,
+  isExclusive,
+  loadWorkspaceConfig,
+} from './workspace-config.js';
 
 const onecli = new OneCLI({ url: ONECLI_URL });
 
@@ -60,9 +66,23 @@ interface VolumeMount {
   readonly: boolean;
 }
 
+/**
+ * Redact a sensitive value from a string (e.g. a token embedded in CLI args).
+ * Used to sanitise log output — never call with an empty string.
+ */
+function redactValue(text: string, sensitiveValue: string): string {
+  if (!sensitiveValue) return text;
+  return text.replace(
+    new RegExp(sensitiveValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
+    '***',
+  );
+}
+
 function buildVolumeMounts(
   group: RegisteredGroup,
   isMain: boolean,
+  extRepoPath: string | null,
+  exclusiveToken: string | null,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
@@ -138,12 +158,16 @@ function buildVolumeMounts(
   );
   fs.mkdirSync(groupSessionsDir, { recursive: true });
   const settingsFile = path.join(groupSessionsDir, 'settings.json');
+  // Exclusive workspace mode uses the per-repo token; monorepo mode uses the host GH_TOKEN.
+  // The settings.json is written to the per-group sessions directory which is bind-mounted
+  // into the container, so this is the authoritative source for the container's GH_TOKEN.
+  const ghTokenForContainer = exclusiveToken ?? process.env.GH_TOKEN ?? '';
   const defaultEnv: Record<string, string> = {
     CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
     CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
     CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
-    GH_TOKEN: process.env.GH_TOKEN || '',
-    GITHUB_TOKEN: process.env.GH_TOKEN || '',
+    GH_TOKEN: ghTokenForContainer,
+    GITHUB_TOKEN: ghTokenForContainer,
   };
   // Merge containerConfig.envVars (e.g., AGENT_ROLE, AGENT_SCOPE)
   const groupEnvVars = group.containerConfig?.envVars || {};
@@ -226,8 +250,17 @@ function buildVolumeMounts(
     mounts.push(...validatedMounts);
   }
 
-  // Mount git worktree for worker groups (created by register_group IPC handler)
-  if (!isMain && WORKTREE_BASE && group.containerConfig?.envVars?.AGENT_SCOPE) {
+  if (!isMain && extRepoPath) {
+    // Exclusive workspace mode: mount the freshly-cloned external repo at a
+    // distinct path so the Architect always knows it's not the monorepo.
+    // The limitless monorepo is deliberately NOT mounted (IP isolation).
+    mounts.push({
+      hostPath: extRepoPath,
+      containerPath: '/workspace/extra/repo',
+      readonly: false,
+    });
+  } else if (!isMain && WORKTREE_BASE && group.containerConfig?.envVars?.AGENT_SCOPE) {
+    // Monorepo mode: mount the git worktree created by the register_group IPC handler.
     const worktreeDir = path.join(WORKTREE_BASE, group.folder);
     if (fs.existsSync(worktreeDir)) {
       mounts.push({
@@ -258,14 +291,21 @@ async function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
   agentIdentifier?: string,
+  exclusiveToken?: string | null,
 ): Promise<string[]> {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
 
-  // Pass GitHub token for git push + PR creation in worker containers
-  if (process.env.GH_TOKEN) {
+  // Inject GitHub token for git operations inside the container.
+  // Exclusive workspace mode: inject the per-repo token from the configured
+  // env var — do NOT also inject the host GH_TOKEN (one token per container).
+  // Monorepo mode: inject the host GH_TOKEN as before.
+  if (exclusiveToken) {
+    args.push('-e', `GH_TOKEN=${exclusiveToken}`);
+    args.push('-e', `GITHUB_TOKEN=${exclusiveToken}`);
+  } else if (process.env.GH_TOKEN) {
     args.push('-e', `GH_TOKEN=${process.env.GH_TOKEN}`);
     args.push('-e', `GITHUB_TOKEN=${process.env.GH_TOKEN}`);
   }
@@ -318,13 +358,57 @@ export async function runContainerAgent(
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<ContainerOutput> {
   const startTime = Date.now();
+  const runId = String(startTime);
 
   const groupDir = resolveGroupFolderPath(group.folder);
   fs.mkdirSync(groupDir, { recursive: true });
 
-  const mounts = buildVolumeMounts(group, input.isMain);
+  // ── Workspace config: determine repo source (monorepo or exclusive) ──────
+  let workspaceConfig: ReturnType<typeof loadWorkspaceConfig> = null;
+  let extRepoPath: string | null = null;
+  let exclusiveToken: string | null = null;
+
+  if (!input.isMain) {
+    try {
+      workspaceConfig = loadWorkspaceConfig(group.folder);
+    } catch (err) {
+      return {
+        status: 'error',
+        result: null,
+        error: `Invalid workspace.json for group "${group.folder}": ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    if (isExclusive(workspaceConfig)) {
+      const cfg = workspaceConfig as ExclusiveWorkspaceConfig;
+      exclusiveToken = process.env[cfg.tokenEnvVar] ?? null;
+      if (!exclusiveToken) {
+        return {
+          status: 'error',
+          result: null,
+          error: `Exclusive workspace requires env var "${cfg.tokenEnvVar}" but it is not set on the host`,
+        };
+      }
+      try {
+        extRepoPath = await cloneExternalRepo(
+          cfg.repo,
+          cfg.branch,
+          exclusiveToken,
+          runId,
+        );
+      } catch (err) {
+        return {
+          status: 'error',
+          result: null,
+          error: `Failed to clone external repo "${cfg.repo}": ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    }
+  }
+
+  const mounts = buildVolumeMounts(group, input.isMain, extRepoPath, exclusiveToken);
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
-  const containerName = `nanoclaw-${safeName}-${Date.now()}`;
+  const containerName = `nanoclaw-${safeName}-${runId}`;
   // Main group uses the default OneCLI agent; others use their own agent.
   const agentIdentifier = input.isMain
     ? undefined
@@ -333,17 +417,24 @@ export async function runContainerAgent(
     mounts,
     containerName,
     agentIdentifier,
+    exclusiveToken,
   );
+
+  // Redact the exclusive token from any log output that includes container args.
+  const safeArgsLog = exclusiveToken
+    ? redactValue(containerArgs.join(' '), exclusiveToken)
+    : containerArgs.join(' ');
 
   logger.debug(
     {
       group: group.name,
       containerName,
+      workspaceMode: workspaceConfig?.mode ?? 'monorepo',
       mounts: mounts.map(
         (m) =>
           `${m.hostPath} -> ${m.containerPath}${m.readonly ? ' (ro)' : ''}`,
       ),
-      containerArgs: containerArgs.join(' '),
+      containerArgs: safeArgsLog,
     },
     'Container mount configuration',
   );
@@ -490,6 +581,18 @@ export async function runContainerAgent(
     container.on('close', (code) => {
       clearTimeout(timeout);
       const duration = Date.now() - startTime;
+
+      // Clean up the external repo clone for exclusive workspace runs.
+      // This is intentionally fire-and-forget — a cleanup failure must not
+      // affect the result returned to the caller.
+      if (extRepoPath) {
+        try {
+          fs.rmSync(extRepoPath, { recursive: true, force: true });
+          logger.debug({ extRepoPath }, 'External repo clone cleaned up');
+        } catch (err) {
+          logger.warn({ extRepoPath, err }, 'Failed to clean up external repo clone');
+        }
+      }
 
       if (timedOut) {
         const ts = new Date().toISOString().replace(/[:.]/g, '-');

--- a/apps/nanoclaw/src/workspace-config.test.ts
+++ b/apps/nanoclaw/src/workspace-config.test.ts
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock fs — individual tests control what readFileSync / existsSync return
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(() => ''),
+      mkdirSync: vi.fn(),
+    },
+  };
+});
+
+// Mock config — use a stable test groups dir
+vi.mock('./config.js', () => ({
+  GROUPS_DIR: '/tmp/test-groups',
+  EXT_REPOS_BASE: '/tmp/test-ext-repos',
+}));
+
+// Mock logger to suppress output
+vi.mock('./logger.js', () => ({
+  logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Mock child_process.spawn for cloneExternalRepo tests
+vi.mock('child_process', async () => {
+  const actual =
+    await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import fs from 'fs';
+import { spawn } from 'child_process';
+import {
+  cloneExternalRepo,
+  isExclusive,
+  loadWorkspaceConfig,
+} from './workspace-config.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockWorkspaceFile(content: string): void {
+  vi.mocked(fs.existsSync).mockReturnValue(true);
+  vi.mocked(fs.readFileSync).mockReturnValue(content);
+}
+
+function mockWorkspaceAbsent(): void {
+  vi.mocked(fs.existsSync).mockReturnValue(false);
+}
+
+function createFakeGitProcess(exitCode = 0) {
+  const proc = new EventEmitter() as EventEmitter & {
+    stderr: PassThrough;
+    stdout: PassThrough;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  proc.stderr = new PassThrough();
+  proc.stdout = new PassThrough();
+  proc.kill = vi.fn();
+  // Emit close on the next tick
+  setTimeout(() => proc.emit('close', exitCode), 0);
+  return proc;
+}
+
+// ─── loadWorkspaceConfig — absent file ───────────────────────────────────────
+
+describe('loadWorkspaceConfig — absent file', () => {
+  beforeEach(() => mockWorkspaceAbsent());
+
+  it('returns null when workspace.json does not exist', () => {
+    const result = loadWorkspaceConfig('my-group');
+    expect(result).toBeNull();
+  });
+});
+
+// ─── loadWorkspaceConfig — monorepo mode ─────────────────────────────────────
+
+describe('loadWorkspaceConfig — monorepo mode', () => {
+  it('parses mode: "monorepo"', () => {
+    mockWorkspaceFile(JSON.stringify({ mode: 'monorepo' }));
+    const result = loadWorkspaceConfig('my-group');
+    expect(result).toEqual({ mode: 'monorepo' });
+  });
+
+  it('isExclusive returns false for monorepo config', () => {
+    mockWorkspaceFile(JSON.stringify({ mode: 'monorepo' }));
+    const result = loadWorkspaceConfig('my-group');
+    expect(isExclusive(result)).toBe(false);
+  });
+
+  it('isExclusive returns false for null', () => {
+    expect(isExclusive(null)).toBe(false);
+  });
+});
+
+// ─── loadWorkspaceConfig — exclusive mode ────────────────────────────────────
+
+describe('loadWorkspaceConfig — exclusive mode', () => {
+  const validConfig = {
+    mode: 'exclusive',
+    repo: 'chmod735-dor/mythos',
+    branch: 'main',
+    tokenEnvVar: 'GH_PAT_TOKEN_MYTHOS',
+  };
+
+  it('parses a valid exclusive config', () => {
+    mockWorkspaceFile(JSON.stringify(validConfig));
+    const result = loadWorkspaceConfig('my-group');
+    expect(result).toEqual(validConfig);
+  });
+
+  it('isExclusive returns true for exclusive config', () => {
+    mockWorkspaceFile(JSON.stringify(validConfig));
+    const result = loadWorkspaceConfig('my-group');
+    expect(isExclusive(result)).toBe(true);
+  });
+
+  it('accepts branch names with slashes and hyphens', () => {
+    mockWorkspaceFile(
+      JSON.stringify({ ...validConfig, branch: 'feat/some-feature' }),
+    );
+    const result = loadWorkspaceConfig('my-group');
+    expect(result).not.toBeNull();
+    if (result && 'branch' in result) {
+      expect(result.branch).toBe('feat/some-feature');
+    }
+  });
+
+  it('accepts repo names with dots and underscores', () => {
+    mockWorkspaceFile(
+      JSON.stringify({ ...validConfig, repo: 'org.name/repo_name.ext' }),
+    );
+    const result = loadWorkspaceConfig('my-group');
+    expect(result).not.toBeNull();
+  });
+});
+
+// ─── loadWorkspaceConfig — error cases ───────────────────────────────────────
+
+describe('loadWorkspaceConfig — error cases', () => {
+  it('throws on invalid JSON', () => {
+    mockWorkspaceFile('{not valid json}');
+    expect(() => loadWorkspaceConfig('my-group')).toThrow(/not valid JSON/);
+  });
+
+  it('throws when root value is an array', () => {
+    mockWorkspaceFile('[]');
+    expect(() => loadWorkspaceConfig('my-group')).toThrow(/JSON object/);
+  });
+
+  it('throws when mode is missing', () => {
+    mockWorkspaceFile(JSON.stringify({ repo: 'a/b' }));
+    expect(() => loadWorkspaceConfig('my-group')).toThrow(/mode/);
+  });
+
+  it('throws on unknown mode value', () => {
+    mockWorkspaceFile(JSON.stringify({ mode: 'hybrid' }));
+    expect(() => loadWorkspaceConfig('my-group')).toThrow(/mode/);
+  });
+
+  it('throws on exclusive mode without repo', () => {
+    mockWorkspaceFile(
+      JSON.stringify({ mode: 'exclusive', branch: 'main', tokenEnvVar: 'TOKEN' }),
+    );
+    expect(() => loadWorkspaceConfig('my-group')).toThrow(/repo/);
+  });
+
+  it('throws on exclusive mode with invalid repo format (no slash)', () => {
+    mockWorkspaceFile(
+      JSON.stringify({
+        mode: 'exclusive',
+        repo: 'notvalid',
+        branch: 'main',
+        tokenEnvVar: 'TOKEN',
+      }),
+    );
+    expect(() => loadWorkspaceConfig('my-group')).toThrow(/repo/);
+  });
+
+  it('throws on exclusive mode with path-traversal in repo', () => {
+    mockWorkspaceFile(
+      JSON.stringify({
+        mode: 'exclusive',
+        repo: '../../etc/passwd',
+        branch: 'main',
+        tokenEnvVar: 'TOKEN',
+      }),
+    );
+    expect(() => loadWorkspaceConfig('my-group')).toThrow(/repo/);
+  });
+
+  it('throws on exclusive mode without branch', () => {
+    mockWorkspaceFile(
+      JSON.stringify({
+        mode: 'exclusive',
+        repo: 'org/repo',
+        tokenEnvVar: 'TOKEN',
+      }),
+    );
+    expect(() => loadWorkspaceConfig('my-group')).toThrow(/branch/);
+  });
+
+  it('throws on exclusive mode with empty branch', () => {
+    mockWorkspaceFile(
+      JSON.stringify({
+        mode: 'exclusive',
+        repo: 'org/repo',
+        branch: '',
+        tokenEnvVar: 'TOKEN',
+      }),
+    );
+    expect(() => loadWorkspaceConfig('my-group')).toThrow(/branch/);
+  });
+
+  it('throws on exclusive mode without tokenEnvVar', () => {
+    mockWorkspaceFile(
+      JSON.stringify({ mode: 'exclusive', repo: 'org/repo', branch: 'main' }),
+    );
+    expect(() => loadWorkspaceConfig('my-group')).toThrow(/tokenEnvVar/);
+  });
+
+  it('throws on exclusive mode with tokenEnvVar containing shell injection chars', () => {
+    mockWorkspaceFile(
+      JSON.stringify({
+        mode: 'exclusive',
+        repo: 'org/repo',
+        branch: 'main',
+        tokenEnvVar: 'FOO$(rm -rf /)',
+      }),
+    );
+    expect(() => loadWorkspaceConfig('my-group')).toThrow(/tokenEnvVar/);
+  });
+
+  it('throws on exclusive mode with tokenEnvVar containing path separators', () => {
+    mockWorkspaceFile(
+      JSON.stringify({
+        mode: 'exclusive',
+        repo: 'org/repo',
+        branch: 'main',
+        tokenEnvVar: '../../../etc/TOKEN',
+      }),
+    );
+    expect(() => loadWorkspaceConfig('my-group')).toThrow(/tokenEnvVar/);
+  });
+});
+
+// ─── cloneExternalRepo — token redaction ─────────────────────────────────────
+
+describe('cloneExternalRepo', () => {
+  const mockSpawn = vi.mocked(spawn);
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls git clone with the token embedded in the URL', async () => {
+    const fakeProc = createFakeGitProcess(0);
+    mockSpawn.mockReturnValue(fakeProc as unknown as ReturnType<typeof spawn>);
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+
+    await cloneExternalRepo('org/repo', 'main', 'secret-token-abc', 'run-42');
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'git',
+      expect.arrayContaining([
+        expect.stringContaining('secret-token-abc'),
+        '--depth',
+        '1',
+        '--branch',
+        'main',
+      ]),
+      expect.anything(),
+    );
+  });
+
+  it('redacts token from stderr before propagating error message', async () => {
+    const fakeProc = createFakeGitProcess(128);
+    mockSpawn.mockReturnValue(fakeProc as unknown as ReturnType<typeof spawn>);
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+
+    // Start the clone — spawn() is called synchronously inside, attaching the
+    // stderr data listener before any timer fires.
+    const clonePromise = cloneExternalRepo(
+      'org/repo',
+      'main',
+      'secret-token-abc',
+      'run-43',
+    );
+
+    // Push token-containing stderr synchronously (same microtask batch,
+    // before the setTimeout(close, 0) fires) so it is collected and redacted
+    // before the error is built.
+    fakeProc.stderr.push('fatal: secret-token-abc: bad credentials');
+
+    let caughtErr: Error | undefined;
+    try {
+      await clonePromise;
+    } catch (e) {
+      caughtErr = e as Error;
+    }
+    expect(caughtErr?.message).toContain('***');
+    expect(caughtErr?.message).not.toContain('secret-token-abc');
+  });
+
+  it('returns the clone directory path on success', async () => {
+    const fakeProc = createFakeGitProcess(0);
+    mockSpawn.mockReturnValue(fakeProc as unknown as ReturnType<typeof spawn>);
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+
+    const result = await cloneExternalRepo(
+      'chmod735-dor/mythos',
+      'main',
+      'my-token',
+      'run-99',
+    );
+
+    expect(result).toContain('chmod735-dor-mythos-run-99');
+    expect(result).toContain('/tmp/test-ext-repos/');
+  });
+});

--- a/apps/nanoclaw/src/workspace-config.ts
+++ b/apps/nanoclaw/src/workspace-config.ts
@@ -1,0 +1,231 @@
+/**
+ * Workspace configuration for NanoClaw container groups.
+ *
+ * Each group can optionally have a `workspace.json` file in its group folder
+ * that declares which Git repository the Architect container should work
+ * against. Two modes are supported:
+ *
+ *  - "monorepo" (default when file is absent): the existing behaviour —
+ *    a git worktree of the limitless monorepo is mounted at
+ *    /workspace/extra/monorepo inside the container.
+ *
+ *  - "exclusive": an external repository is cloned fresh for each container
+ *    run and mounted at /workspace/extra/repo. The limitless monorepo is NOT
+ *    mounted, enforcing IP isolation by construction.
+ */
+import { ChildProcess, spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { EXT_REPOS_BASE } from './config.js';
+import { resolveGroupFolderPath } from './group-folder.js';
+import { logger } from './logger.js';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type WorkspaceMode = 'monorepo' | 'exclusive';
+
+export interface MonorepoWorkspaceConfig {
+  mode: 'monorepo';
+}
+
+export interface ExclusiveWorkspaceConfig {
+  mode: 'exclusive';
+  /** GitHub "owner/repo" slug (e.g. "chmod735-dor/mythos"). */
+  repo: string;
+  /** Branch to check out (e.g. "main"). */
+  branch: string;
+  /**
+   * Name of a host-side environment variable whose value is used as
+   * GH_TOKEN inside the container. Never hardcoded; must not be logged.
+   */
+  tokenEnvVar: string;
+}
+
+export type WorkspaceConfig = MonorepoWorkspaceConfig | ExclusiveWorkspaceConfig;
+
+export function isExclusive(
+  config: WorkspaceConfig | null,
+): config is ExclusiveWorkspaceConfig {
+  return config?.mode === 'exclusive';
+}
+
+// ─── Validation patterns ─────────────────────────────────────────────────────
+
+// owner/repo: each component alphanumeric + hyphens/dots/underscores, no leading dot/hyphen
+const REPO_PATTERN =
+  /^[A-Za-z0-9][A-Za-z0-9_.-]*\/[A-Za-z0-9][A-Za-z0-9_.-]*$/;
+
+// Standard env var name: letters/underscore, then letters/digits/underscore
+const ENV_VAR_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// Branch names: alphanumeric, hyphens, dots, forward-slashes, underscores
+const BRANCH_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/\-]*$/;
+
+// ─── Parser ──────────────────────────────────────────────────────────────────
+
+/**
+ * Load and validate `workspace.json` from the group's folder.
+ *
+ * Returns `null` when the file is absent (equivalent to `mode: "monorepo"`).
+ * Throws a descriptive Error on invalid content — the caller should surface
+ * this to the operator rather than silently falling back to monorepo mode.
+ */
+export function loadWorkspaceConfig(groupFolder: string): WorkspaceConfig | null {
+  const groupDir = resolveGroupFolderPath(groupFolder);
+  const configPath = path.join(groupDir, 'workspace.json');
+
+  if (!fs.existsSync(configPath)) {
+    return null;
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  } catch (err) {
+    throw new Error(
+      `workspace.json for group "${groupFolder}" is not valid JSON: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error(
+      `workspace.json for group "${groupFolder}" must be a JSON object`,
+    );
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const { mode } = obj;
+
+  if (mode !== 'monorepo' && mode !== 'exclusive') {
+    throw new Error(
+      `workspace.json "mode" must be "monorepo" or "exclusive", got: ${JSON.stringify(mode)}`,
+    );
+  }
+
+  if (mode === 'monorepo') {
+    return { mode: 'monorepo' };
+  }
+
+  // exclusive — validate all required fields
+  const { repo, branch, tokenEnvVar } = obj;
+
+  if (typeof repo !== 'string' || !REPO_PATTERN.test(repo)) {
+    throw new Error(
+      `workspace.json "repo" must be "owner/repo" format, got: ${JSON.stringify(repo)}`,
+    );
+  }
+
+  if (
+    typeof branch !== 'string' ||
+    branch.length === 0 ||
+    !BRANCH_PATTERN.test(branch)
+  ) {
+    throw new Error(
+      `workspace.json "branch" must be a non-empty string with safe characters (alphanumeric, hyphens, dots, slashes, underscores), got: ${JSON.stringify(branch)}`,
+    );
+  }
+
+  if (typeof tokenEnvVar !== 'string' || !ENV_VAR_PATTERN.test(tokenEnvVar)) {
+    throw new Error(
+      `workspace.json "tokenEnvVar" must be a valid environment variable name, got: ${JSON.stringify(tokenEnvVar)}`,
+    );
+  }
+
+  return { mode: 'exclusive', repo, branch, tokenEnvVar };
+}
+
+// ─── Repo cloning ─────────────────────────────────────────────────────────────
+
+const CLONE_TIMEOUT_MS = 120_000; // 2 minutes
+
+/**
+ * Clone an external GitHub repository to a temporary directory.
+ *
+ * Authentication: HTTPS with token embedded in the URL (token is sanitised
+ * from all log output and error messages before they leave this function).
+ *
+ * The caller is responsible for deleting the returned directory when the
+ * container run finishes.
+ */
+export async function cloneExternalRepo(
+  repo: string,
+  branch: string,
+  token: string,
+  runId: string,
+): Promise<string> {
+  const safeSlug = repo.replace(/[^A-Za-z0-9-]/g, '-');
+  const cloneDir = path.join(EXT_REPOS_BASE, `${safeSlug}-${runId}`);
+
+  fs.mkdirSync(cloneDir, { recursive: true });
+
+  // NEVER log cloneUrl — it contains the token.
+  const cloneUrl = `https://x-access-token:${token}@github.com/${repo}.git`;
+
+  logger.info({ repo, branch, cloneDir }, 'Cloning external repo');
+
+  await new Promise<void>((resolve, reject) => {
+    const gitProc: ChildProcess = spawn(
+      'git',
+      [
+        'clone',
+        '--depth',
+        '1',
+        '--branch',
+        branch,
+        '--single-branch',
+        cloneUrl,
+        cloneDir,
+      ],
+      {
+        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+
+    let stderr = '';
+
+    (gitProc.stderr as NodeJS.ReadableStream | null)?.on(
+      'data',
+      (d: Buffer) => {
+        // Redact the token before accumulating stderr
+        stderr += d.toString().replace(
+          new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
+          '***',
+        );
+      },
+    );
+
+    const cloneTimeout = setTimeout(() => {
+      try {
+        gitProc.kill('SIGKILL');
+      } catch {
+        // ignore
+      }
+      reject(new Error(`git clone timed out after ${CLONE_TIMEOUT_MS}ms`));
+    }, CLONE_TIMEOUT_MS);
+
+    gitProc.on('close', (code: number | null) => {
+      clearTimeout(cloneTimeout);
+      if (code === 0) {
+        logger.info({ repo, branch, cloneDir }, 'External repo cloned successfully');
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `git clone failed (exit code ${code ?? 'null'}): ${stderr.slice(-500)}`,
+          ),
+        );
+      }
+    });
+
+    gitProc.on('error', (err: Error) => {
+      clearTimeout(cloneTimeout);
+      reject(new Error(`git clone spawn error: ${err.message}`));
+    });
+  });
+
+  return cloneDir;
+}


### PR DESCRIPTION
## Architecture summary

Adds a per-channel `workspace.json` config file that declares the code workspace for that channel's Architect container. Two modes:

| Mode | Behaviour |
|---|---|
| `"monorepo"` (or file absent) | Unchanged — existing worktree at `/workspace/extra/monorepo`. All 5 current Architects unaffected. |
| `"exclusive"` | External repo cloned fresh per run, mounted at `/workspace/extra/repo`. Limitless monorepo **not** mounted. |

**Schema** (`apps/nanoclaw/groups/discord_<channel>/workspace.json`):
```json
{
  "mode": "exclusive",
  "repo": "chmod735-dor/mythos",
  "branch": "main",
  "tokenEnvVar": "GH_PAT_TOKEN_MYTHOS"
}
```

**No `workspace.json` files are included in this PR.** Channel-specific files (e.g. `discord_mythos-eng/workspace.json`) are Phase 3, separate PR.

### Exclusive mode lifecycle

1. `runContainerAgent` reads `workspace.json` for non-main groups
2. Reads `process.env[tokenEnvVar]` — fails fast if not set (returns error, no container spawned)
3. Clones `https://x-access-token:<token>@github.com/<repo>.git --depth 1 --branch <branch>` to `/tmp/nanoclaw-ext-repos/<slug>-<runId>/`
4. Mounts clone at `/workspace/extra/repo` inside container
5. Injects `GH_TOKEN=<token>` (not the host's default `GH_TOKEN`) into the container
6. On container close: deletes the clone directory

### Token safety

- Token never logged (redacted in all debug/info/error log paths with `redactValue()`)
- Token not written to any file on disk (only injected as container env var and embedded in git clone URL which is never logged)
- Clone URL uses `x-access-token:<token>@github.com` format; only sanitised form (`***`) appears in logs
- `tokenEnvVar` validated as `^[A-Za-z_][A-Za-z0-9_]*$` — no shell injection possible

## Backward-compat proof

The existing 5 Architect channels have no `workspace.json` in their group folders. `loadWorkspaceConfig` returns `null` when the file is absent. In `runContainerAgent`, when `workspaceConfig` is `null` and `isExclusive(null)` returns `false`, the code takes the identical path as before:

- `extRepoPath = null` → no ext repo mount
- `exclusiveToken = null` → `process.env.GH_TOKEN` used (unchanged)
- Worktree mount block: unchanged — `WORKTREE_BASE + group.folder` at `/workspace/extra/monorepo`

The regression test `"does not mount /workspace/extra/repo for monorepo mode"` explicitly verifies this for `loadWorkspaceConfig` returning `null`.

## Test plan output

```
✓ src/workspace-config.test.ts (23 tests) 25ms
✓ src/group-folder.test.ts (5 tests) 6ms
✓ src/container-runner.test.ts (12 tests) 38ms

Test Files  3 passed (3)
Tests       40 passed (40)
```

**workspace-config.test.ts (23 tests):**
- `loadWorkspaceConfig` absent file → null
- Valid monorepo config → `{ mode: "monorepo" }`
- Valid exclusive config → all fields present
- `isExclusive` type guard: true/false/null cases
- Branch names with slashes and hyphens accepted
- 10 error cases: invalid JSON, array root, missing/unknown mode, missing/invalid repo, empty branch, missing/invalid tokenEnvVar, shell injection attempt, path traversal in repo and tokenEnvVar
- `cloneExternalRepo`: spawns git with token in URL, redacts token from error messages, returns correct directory path

**container-runner.test.ts (9 new + 3 existing = 12 tests):**
- Monorepo mode: no `/workspace/extra/repo` mount, `cloneExternalRepo` not called
- Exclusive mode: mounts clone at `/workspace/extra/repo`, no `/workspace/extra/monorepo`, injects exclusive token as `GH_TOKEN`, calls `cloneExternalRepo` with correct args
- Error: `tokenEnvVar` not set → returns error, no clone attempted
- Error: clone fails → returns error
- Main group: workspace config not read (exclusive mode skipped for isMain=true)

## ⚠️ DO NOT deploy to VPS from this PR

Human operator will deploy manually after merge: rebuild `dist/`, `sudo systemctl restart nanoclaw`, verify existing Architects still connect. MYTHOS `workspace.json` and registration are Phase 3.

## References

- LIMITLESS Ops dispatch 2026-04-11 (Phase 2 — MYTHOS infra prep)
- MYTHOS repo: `chmod735-dor/mythos` (separate private repo, IP isolation required)