### PR TITLE
fix(nanoclaw): guard OneCLI when ONECLI_URL unset; inject token directly

### DIFF
--- a/apps/nanoclaw/src/config.ts
+++ b/apps/nanoclaw/src/config.ts
@@ -52,7 +52,7 @@ export const CONTAINER_MAX_OUTPUT_SIZE = parseInt(
   10,
 ); // 10MB default
 export const ONECLI_URL =
-  process.env.ONECLI_URL || envConfig.ONECLI_URL || 'http://localhost:10254';
+  process.env.ONECLI_URL || envConfig.ONECLI_URL || '';
 export const MAX_MESSAGES_PER_PROMPT = Math.max(
   1,
   parseInt(process.env.MAX_MESSAGES_PER_PROMPT || '10', 10) || 10,

--- a/apps/nanoclaw/src/container-runner.test.ts
+++ b/apps/nanoclaw/src/container-runner.test.ts
@@ -227,3 +227,100 @@ describe('container-runner timeout behavior', () => {
     expect(result.newSessionId).toBe('session-456');
   });
 });
+
+describe('OneCLI guard — ONECLI_URL empty', () => {
+  // Re-import container-runner with ONECLI_URL='' to test the guard path.
+  // vi.resetModules() + vi.doMock() lets us override the hoisted config mock
+  // for this describe block only.
+  let runContainerAgentNoOneCLI: typeof import('./container-runner.js').runContainerAgent;
+  let mockApplyContainerConfig: ReturnType<typeof vi.fn>;
+
+  beforeAll(async () => {
+    mockApplyContainerConfig = vi.fn().mockResolvedValue(true);
+    vi.resetModules();
+    vi.doMock('./config.js', () => ({
+      CONTAINER_IMAGE: 'nanoclaw-agent:latest',
+      CONTAINER_MAX_OUTPUT_SIZE: 10485760,
+      CONTAINER_TIMEOUT: 1800000,
+      DATA_DIR: '/tmp/nanoclaw-test-data',
+      GROUPS_DIR: '/tmp/nanoclaw-test-groups',
+      IDLE_TIMEOUT: 1800000,
+      ONECLI_URL: '', // intentionally empty — exercises the guard branch
+      TIMEZONE: 'UTC',
+      MONOREPO_PATH: '',
+      WORKTREE_BASE: '/tmp/nanoclaw-worktrees',
+    }));
+    vi.doMock('@onecli-sh/sdk', () => ({
+      OneCLI: class {
+        applyContainerConfig = mockApplyContainerConfig;
+        createAgent = vi.fn();
+        ensureAgent = vi.fn();
+      },
+    }));
+    const mod = await import('./container-runner.js');
+    runContainerAgentNoOneCLI = mod.runContainerAgent;
+  });
+
+  afterAll(() => {
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+    mockApplyContainerConfig.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not call OneCLI.applyContainerConfig when ONECLI_URL is empty', async () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token-xyz';
+
+    const resultPromise = runContainerAgentNoOneCLI(
+      testGroup,
+      testInput,
+      () => {},
+    );
+
+    emitOutputMarker(fakeProc, { status: 'success', result: 'Done' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    expect(mockApplyContainerConfig).not.toHaveBeenCalled();
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  });
+
+  it('injects CLAUDE_CODE_OAUTH_TOKEN via -e when ONECLI_URL is empty', async () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token-xyz';
+
+    const { spawn } = await import('child_process');
+    const spawnMock = spawn as ReturnType<typeof vi.fn>;
+    spawnMock.mockClear();
+
+    const resultPromise = runContainerAgentNoOneCLI(
+      testGroup,
+      testInput,
+      () => {},
+    );
+
+    emitOutputMarker(fakeProc, { status: 'success', result: 'Done' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    const dockerArgs = spawnMock.mock.calls[0]?.[1] as string[] | undefined;
+    expect(dockerArgs).toBeDefined();
+    const tokenArgIdx = dockerArgs!.findIndex(
+      (a, i, arr) =>
+        a === '-e' && arr[i + 1]?.startsWith('CLAUDE_CODE_OAUTH_TOKEN='),
+    );
+    expect(tokenArgIdx).not.toBe(-1);
+
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  });
+});

--- a/apps/nanoclaw/src/container-runner.ts
+++ b/apps/nanoclaw/src/container-runner.ts
@@ -81,7 +81,7 @@ function buildVolumeMounts(
     });
 
     // Shadow .env so the agent cannot read secrets from the mounted project root.
-    // Credentials are injected by the OneCLI gateway, never exposed to containers.
+    // Credentials are injected by OneCLI (when configured) or passed via -e flags.
     const envFile = path.join(projectRoot, '.env');
     if (fs.existsSync(envFile)) {
       mounts.push({
@@ -270,19 +270,38 @@ async function buildContainerArgs(
     args.push('-e', `GITHUB_TOKEN=${process.env.GH_TOKEN}`);
   }
 
-  // OneCLI gateway handles credential injection — containers never see real secrets.
-  // The gateway intercepts HTTPS traffic and injects API keys or OAuth tokens.
-  const onecliApplied = await onecli.applyContainerConfig(args, {
-    addHostMapping: false, // Nanoclaw already handles host gateway
-    agent: agentIdentifier,
-  });
-  if (onecliApplied) {
-    logger.info({ containerName }, 'OneCLI gateway config applied');
+  if (ONECLI_URL) {
+    // OneCLI gateway handles credential injection — the gateway intercepts
+    // HTTPS traffic and injects API keys or OAuth tokens so containers never
+    // see the raw secrets.
+    const onecliApplied = await onecli.applyContainerConfig(args, {
+      addHostMapping: false, // Nanoclaw already handles host gateway
+      agent: agentIdentifier,
+    });
+    if (onecliApplied) {
+      logger.info({ containerName }, 'OneCLI gateway config applied');
+    } else {
+      logger.warn(
+        { containerName },
+        'OneCLI gateway not reachable — container will have no credentials',
+      );
+    }
   } else {
-    logger.warn(
-      { containerName },
-      'OneCLI gateway not reachable — container will have no credentials',
-    );
+    // No OneCLI gateway configured — pass CLAUDE_CODE_OAUTH_TOKEN directly
+    // via -e. The token is visible in `docker inspect` on the host; acceptable
+    // for a single-operator VPS where no untrusted users have access.
+    if (process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+      args.push('-e', `CLAUDE_CODE_OAUTH_TOKEN=${process.env.CLAUDE_CODE_OAUTH_TOKEN}`);
+      logger.info(
+        { containerName },
+        'OneCLI not configured — CLAUDE_CODE_OAUTH_TOKEN injected directly',
+      );
+    } else {
+      logger.warn(
+        { containerName },
+        'OneCLI not configured and CLAUDE_CODE_OAUTH_TOKEN unset — container will have no Anthropic credentials',
+      );
+    }
   }
 
   // Runtime-specific args for host gateway resolution


### PR DESCRIPTION
## Problem

Two tenants (LIMITLESS + MYTHOS) run NanoClaw on the same VPS as different OS users. MYTHOS has `ONECLI_URL=""` in its `.env` (OneCLI wiring deferred for MVP). Instead of skipping OneCLI, NanoClaw was connecting to the LIMITLESS tenant's OneCLI instance at `localhost:10254` and failing with `EACCES: permission denied, open '/tmp/onecli-proxy-ca.pem'` on every message.

### Root cause

`config.ts` used `||` (not `??`) to resolve `ONECLI_URL`:
```ts
process.env.ONECLI_URL || envConfig.ONECLI_URL || 'http://localhost:10254'
```
Empty string `""` is falsy under `||`, so it fell through to the hardcoded `localhost:10254` default — silently connecting to the co-tenant's OneCLI. `getContainerConfig` succeeded (same VPS, same localhost), then `writeCaCertificate` tried to overwrite `/tmp/onecli-proxy-ca.pem` owned by `limitless:limitless` 600 → EACCES. 4 retries, then drop.

## Fix

**`config.ts`**: Remove the `'http://localhost:10254'` hardcoded fallback. If `ONECLI_URL` is unset/empty, it stays `''`.

**`container-runner.ts`**: Guard `onecli.applyContainerConfig` behind `if (ONECLI_URL)`. When the guard is false, inject `CLAUDE_CODE_OAUTH_TOKEN` directly via `-e`, the same way `GH_TOKEN` is already handled.

### Security note
Passing `CLAUDE_CODE_OAUTH_TOKEN` via `-e` makes the token visible in `docker inspect` on the host. This is an accepted tradeoff for a single-operator VPS where no untrusted users have host access. LIMITLESS tenant is unaffected — it has `ONECLI_URL` explicitly set, so it continues to use the gateway path.

## Deploy instructions

**MYTHOS tenant** (the fix): set `ONECLI_URL=` (empty or omit entirely) in `/home/mythos/nanoclaw/.env` and set `CLAUDE_CODE_OAUTH_TOKEN=<shared-subscription-token>`. Restart `nanoclaw-mythos.service`.

**LIMITLESS tenant** (no change needed): `ONECLI_URL=http://localhost:10254` is set explicitly → continues using OneCLI gateway path unchanged.

## Test plan
- [ ] New unit tests: `OneCLI guard — ONECLI_URL empty` (2 cases: no `applyContainerConfig` call; token in docker args)
- [ ] MYTHOS smoke test: dispatch message to `#mythos-eng`, confirm container spawns without EACCES
- [ ] LIMITLESS regression: dispatch message, confirm OneCLI gateway path still applied (`OneCLI gateway config applied` in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)