### PR TITLE
chore(governance): add CODEOWNERS and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# LIMITLESS monorepo — CODEOWNERS
+# CEO is default approver for all paths.
+* @chmod735
+
+# Per-app domain ownership (CEO + app Architect)
+# Architect handles PR authorship; CEO handles ratification.
+apps/paths/           @chmod735
+apps/cubes/           @chmod735
+apps/hub/             @chmod735
+apps/digital-twin/    @chmod735
+apps/nanoclaw/        @chmod735
+apps/os-dashboard/    @chmod735
+infra/                @chmod735
+docs/                 @chmod735

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- What this PR does and why -->
+
+## Test evidence
+
+<!-- Build output or "no testable change" -->
+
+## Review checklist
+
+- [ ] Change does what the PR title says
+- [ ] Build and tests pass
+- [ ] No unintended side effects on other apps
+- [ ] No secrets or credentials in diff
+
+🤖 Agent-authored — human ratification required before merge.


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` per §4.1 of the Agentic SDLC Governance spec
- Adds `.github/pull_request_template.md` per §7.2 of the spec
- Rollout Step 3 (LIMITLESS backport) per §12.3

## Test evidence

N/A — configuration files only, no build impact

## Review checklist

- [x] Change does what the PR title says
- [x] Build and tests pass (skipped — no code change)
- [x] No unintended side effects on other apps
- [x] No secrets or credentials in diff

Merge approval ritual: reply with approving review containing `RATIFIED` before merging.

🤖 Director-authored — human ratification required before merge.