### PR TITLE
docs: resolve agent-identity + ratification-flow gap (DR-001 + spec v1.1 + rollout plan)

### DIFF
--- a/docs/decisions/DR-001-agent-identity-and-ratification-flow.md
+++ b/docs/decisions/DR-001-agent-identity-and-ratification-flow.md
@@ -1,0 +1,226 @@
+# DR-001 — Agent Identity and Ratification Flow
+
+**Date**: 2026-04-19
+**Author**: Architect
+**Status**: Proposed — awaiting CEO ratification
+**Applies to**: `LIMITLESS-LONGEVITY/limitless` · `chmod735-dor/mythos` · `chmod735-dor/mythos-ops` · all future repos under this division
+**Supersedes**: Ad-hoc Comment-type review workaround (`RATIFIED` keyword) in use since governance spec v1 rollout
+
+---
+
+## Decision
+
+Adopt **GitHub Apps** as the canonical identity mechanism for all LIMITLESS and MYTHOS AI agents. Deploy two GitHub App registrations:
+
+- **`limitless-agent`** — installed on `LIMITLESS-LONGEVITY/limitless`. Covers the main-ops Architect, all five per-app Architects (PATHS, Cubes+, HUB, DT, Infra), and all future LIMITLESS automation agents.
+- **`mythos-agent`** — installed on `chmod735-dor/mythos` and `chmod735-dor/mythos-ops`. Covers the MYTHOS Architect and all future MYTHOS automation agents (test-engineer, verifier, deployment verifier, etc.).
+
+Each App generates a short-lived installation access token (1-hour TTL) at NanoClaw container spawn time. This token replaces the CEO's `GH_TOKEN` as the git and GitHub CLI credential injected into agent containers. Agent commits and PRs are attributed to `limitless-agent[bot]` or `mythos-agent[bot]` — GitHub synthetic bot user accounts that are categorically distinct from the CEO's human account (`chmod735`).
+
+This restores the formal Approving Review flow required by §5.1 of the governance spec: `chmod735` approves `limitless-agent[bot]`'s or `mythos-agent[bot]`'s PRs without triggering GitHub's self-approval block.
+
+**Attribution hierarchy:**
+| Layer | What it records | Where it appears |
+|---|---|---|
+| GitHub author | `limitless-agent[bot]` or `mythos-agent[bot]` — the NanoClaw agent system that pushed | Commit history, PR author field, org audit log |
+| AI model | `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` trailer — the model that generated the content | Commit message footer |
+| Ratifier | `chmod735` (CEO) — the human who reviewed and approved | Squash merge commit author; PR "Approved by" field |
+
+The existing `Co-Authored-By` trailer is retained unchanged.
+
+---
+
+## Context
+
+### The Gap
+
+Governance spec v1 §5.1 requires a GitHub **Approving Review** (not a Comment) as the MiFID II ratification primitive. In practice, all agent-authored PRs are pushed using `GH_TOKEN` — which is the CEO's personal OAuth token, resolving to `chmod735`. GitHub's self-approval restriction unconditionally blocks `chmod735` from approving PRs authored by `chmod735`. The spec's ratification mechanism (§5.1 condition #2) is therefore structurally unreachable.
+
+Interim mitigation in use: Comment-type review with `RATIFIED` keyword + squash merge. This preserves audit record content but does not produce a formal Approving Review state. It is not §5.1-compliant and must not be canonized as the permanent solution.
+
+### Root Cause
+
+Identity conflation: agents commit and push as the CEO's GitHub account because NanoClaw injects `GH_TOKEN=${process.env.GH_TOKEN}` and `GITHUB_TOKEN=${process.env.GH_TOKEN}` into agent containers (container-runner.ts lines ~145–146, ~268–270), and `GH_TOKEN` on the host is the CEO's personal OAuth token. This was appropriate for an early-stage system with one human and no governance requirements. It is incompatible with the governance model adopted in spec v1.
+
+### Consequences of Conflation Beyond Self-Approval
+
+1. **Muddied audit trail** — GitHub PR history shows every agent PR as authored by `chmod735`, indistinguishable from human-authored PRs.
+2. **False impression for third-party auditors** — A MiFID II regulatory reviewer or security auditor would conclude the CEO personally authored all code. This is incorrect and potentially problematic.
+3. **No per-agent attribution** — As the agent fleet grows (test-engineer, verifier, deployment agents), all remain indistinguishable.
+4. **Identity violation as a principle** — Agents are not humans. They must not be represented as such in any system of record.
+
+---
+
+## Options Considered
+
+### Option A — Single Shared Bot User Account
+
+Create one GitHub machine user account (`limitless-agent-bot`). All agents share one fine-grained PAT. Commits and PRs attributed to `limitless-agent-bot`.
+
+**Evaluation against nine criteria:**
+
+| Criterion | Assessment |
+|---|---|
+| Agent ≠ human identity | ✅ Distinct from `chmod735` |
+| Clean Approving Review flow | ✅ CEO approves `limitless-agent-bot`'s PRs — no self-approval block |
+| Cryptographic attribution (signed commits) | ⚠️ Manual GPG key setup required; commits unsigned by default |
+| Works for all current + future agents | ✅ Single shared account works; no per-agent granularity |
+| Per-agent vs per-division attribution | ❌ Zero granularity — all agents identical in audit trail |
+| Commit trailer continuity | ✅ `Co-Authored-By` trailer unchanged |
+| Collaborator team compatibility | ✅ No impact on human contributor workflow |
+| Multi-human ratification scale | ✅ Additional reviewers can approve `limitless-agent-bot`'s PRs cleanly |
+| MiFID II audit unchanged or improved | ⚠️ No degradation; no improvement in attribution clarity |
+| Self-correction path | ⚠️ PAT rotation is manual; 2FA requires TOTP secret in password manager |
+
+**Additional concerns:**
+- Consumes one GitHub org seat ($4–21/mo depending on plan tier).
+- GitHub requires 2FA for org members; bot account 2FA is operationally burdensome (TOTP secret must be stored separately, used to generate codes via `oathtool` or similar).
+- Fine-grained PATs (GA March 2025) require org-owner approval flow before first activation — adds provisioning friction.
+- Classic PATs are on GitHub's deprecation path.
+- No `[bot]` badge in UI — agent commits visually indistinguishable from human commits.
+
+**Assessment**: Fixes the self-approval problem. Operationally simpler than Option B but heavier than Option C. Acceptable as a fallback; not preferred.
+
+---
+
+### Option B — Per-Architect Bot Accounts
+
+One GitHub machine user account per Architect role: `limitless-main-arch-bot`, `paths-arch-bot`, `cubes-arch-bot`, `hub-arch-bot`, `dt-arch-bot`, `infra-arch-bot`, `mythos-arch-bot`. Each gets its own fine-grained PAT.
+
+**Evaluation:**
+
+| Criterion | Assessment |
+|---|---|
+| Agent ≠ human identity | ✅ Each Architect is distinct from CEO and from each other |
+| Clean Approving Review flow | ✅ CEO approves any `*-arch-bot` PR cleanly |
+| Cryptographic attribution | ⚠️ GPG key per account — 7+ keys to generate, store, and rotate |
+| Works for all agents | ⚠️ Works but requires provisioning N new accounts as fleet expands |
+| Per-agent vs per-division attribution | ✅ Maximum per-agent granularity |
+| Commit trailer continuity | ✅ Unchanged |
+| Collaborator compatibility | ✅ No impact |
+| Multi-human ratification scale | ✅ Clean |
+| MiFID II audit | ✅ Best attribution granularity — distinguishes Architect from test-engineer etc. |
+| Self-correction path | ❌ N PATs, N 2FA setups, N rotation schedules — debt multiplies with fleet size |
+
+**Additional concerns:**
+- 7 GitHub org seats minimum today; grows as agent types expand (test-engineer, verifier, deployment agent adds 3+ more).
+- GitHub ToS §B.3: machine accounts are permitted but must be created by a human and consume paid seats. "No more than one **free** machine account per human" — each additional account requires a paid seat.
+- At 10 agents: $40–210/mo in seat cost.
+- 2FA per account: 7+ TOTP secrets.
+- PAT rotation: 7+ schedules (or use shared rotation tooling, which adds complexity).
+
+**Assessment**: Best audit-trail granularity. Disproportionate operational cost at current and projected scale. Not recommended.
+
+---
+
+### Option C — GitHub Apps per Division *(Chosen)*
+
+Register two GitHub Apps under the `LIMITLESS-LONGEVITY` organization. Install each on the appropriate repositories. NanoClaw generates short-lived installation access tokens at container spawn time using each App's private key.
+
+**Evaluation:**
+
+| Criterion | Assessment |
+|---|---|
+| Agent ≠ human identity | ✅ `[bot]` suffix is a GitHub-native categorical marker for non-human identities |
+| Clean Approving Review flow | ✅ GitHub's endorsed automation model. `chmod735` approving `limitless-agent[bot]`'s PR is the normal flow — not a workaround. |
+| Cryptographic attribution (signed commits) | ✅ Commits via GitHub Contents API are auto-signed by GitHub. `git push` commits on PR branches are unsigned — this is acceptable because the signed commits requirement on `main` is satisfied by the CEO squash merge (GitHub server-side signs it). |
+| Works for all current + future agents | ✅ All LIMITLESS agents share one App; all MYTHOS agents share one App. Adding new agent types requires no new App provisioning. |
+| Per-agent vs per-division attribution | ✅ Division-level identity now. Per-agent expansion available by registering additional Apps when needed (no architectural change). |
+| Commit trailer continuity | ✅ `Co-Authored-By` trailer retained; per-agent attribution via `Authored-by-agent:` commit footer convention. |
+| Collaborator compatibility | ✅ Human contributors author their own PRs natively — no intersection with App token flow. |
+| Multi-human ratification scale | ✅ CEO + Safety Reviewer both review `[bot]`-authored PRs. No self-approval concern for either. |
+| MiFID II audit unchanged or improved | ✅ Improved: `[bot]` authorship in PR author field is unambiguous to any auditor. Division attribution (`mythos-agent[bot]`) is appropriate for current MiFID II scope. |
+| Self-correction path | ✅ GitHub supports multiple private keys per App for zero-downtime rotation. Immediate fallback: Option A (bot user account) activatable in <1 hour. Full recovery documented in rollout plan. |
+
+**Additional benefits:**
+- **Zero GitHub seat cost** — Apps do not consume org member seats. Cost is identical at 2 agents or 20 agents.
+- **No 2FA management** — Apps authenticate via JWT signed with RSA private key. No TOTP secrets, no 2FA enrollment.
+- **Minimum-scope tokens** — Each installation token can be scoped at generation time to `contents: write`, `pull-requests: write`, `metadata: read` only. Blast radius of a compromised token: 1 hour, minimum permissions.
+- **GitHub's official long-term recommendation** — "Apps are not user-dependent and survive if the creating user leaves the org." GitHub's stated roadmap deprecates classic PATs; fine-grained PATs add friction; Apps are the endorsed path.
+- **Org audit log separation** — App installation activity appears in a separate audit log category from human user activity. Clear compliance paper trail.
+- **`[bot]` badge in GitHub UI** — Immediately legible. Every reviewer, auditor, and external contributor sees at a glance that the PR was authored by an automated system.
+
+**Note on signed commits (MYTHOS §1.2 requirement)**:
+The "Require signed commits" ruleset on `main` applies to commits pushed *to* `main`. Agents push to PR branches — not `main`. When the CEO clicks "Squash and merge" on a PR via the GitHub web UI, GitHub creates the squash commit server-side and signs it automatically with GitHub's web-flow signing key. This produces a "Verified" squash commit on `main` without requiring CEO local GPG/SSH configuration. The signed commits requirement is therefore satisfied by the merge mechanism itself. See also: Open Question resolution in governance spec v1.1 §Open Questions item 3.
+
+---
+
+### Option D — Signed-Commits-Only Attribution (No Identity Change)
+
+CEO's identity remains as author; agent attribution via GPG-signed `Co-Authored-By` trailers only.
+
+**Assessment**: Does not fix the self-approval problem — CEO is still both author and sole available approver. **Rejected without further evaluation.**
+
+---
+
+## Decision Rationale
+
+Option C is selected for the following reasons, in priority order:
+
+1. **First-principles correctness**: GitHub Apps produce a `[bot]` identity that is structurally non-human. This accurately represents what a NanoClaw agent is. The conflation of agent identity with CEO identity is a category error. Option C resolves it at the root.
+
+2. **§5.1 restoration without workaround**: `chmod735` approving `limitless-agent[bot]`'s PR is the standard GitHub flow for human-ratifies-automation. No bypass rules, no ruleset exceptions, no special CODEOWNERS entries. The spec works as designed.
+
+3. **Zero scaling cost**: As the agent fleet grows from 7 to 15+ agent types, zero additional seat cost or 2FA overhead is incurred. Option B's cost scales linearly with fleet size; Option C's does not.
+
+4. **Operational simplicity at scale**: Two private keys to manage (one per App). Installation tokens expire automatically — no rotation debt accumulates. Contrast with Option B: N PATs + N 2FA setups + N rotation schedules.
+
+5. **GitHub's direction**: Classic PATs are deprecated. Fine-grained PATs require org-approval flows. Apps are GitHub's documented long-term path for automation identity. Building on this foundation avoids forced migration later.
+
+6. **MiFID II compatibility**: `limitless-agent[bot]` and `mythos-agent[bot]` are auditor-legible. A third-party MiFID II reviewer immediately understands that bot-authored, CEO-ratified PRs represent the design intent: AI proposes, human ratifies.
+
+7. **Expansion path**: If per-agent attribution is required in the future (e.g., regulatory requirement to distinguish MYTHOS Architect from MYTHOS test-engineer), additional Apps can be registered incrementally. No architectural change.
+
+---
+
+## Consequences
+
+### Positive
+
+- §5.1 ratification mechanism is fully restored. CEO clicks "Approve" on agent PRs. Formal Approving Review state is recorded in GitHub's PR history.
+- PR author field shows `limitless-agent[bot]` — unambiguously non-human.
+- Org audit log cleanly separates automated agent activity from human CEO activity.
+- Zero new monthly cost regardless of agent fleet growth.
+- No 2FA management for bot identities.
+- Installation token blast radius: 1 hour, minimum scoped permissions.
+- `[RESOLVED: signed commits tooling]` — Squash merge via GitHub web UI is GitHub-signed automatically; CEO local GPG/SSH configuration is not required for branch protection to function.
+
+### Negative / Trade-offs
+
+- **Implementation effort in NanoClaw**: `container-runner.ts` must be updated to generate an installation token at spawn time (JWT sign → exchange for token → inject as `GH_TOKEN`). Estimated complexity: medium (one NanoClaw engineer sprint). This PR covers plan only — implementation requires a separate engineer handoff.
+- **Private key security**: Each App's RSA private key (~2 KB PEM) must be stored in NanoClaw's `.env` (`LIMITLESS_APP_PRIVATE_KEY`, `MYTHOS_APP_PRIVATE_KEY`). These replace the CEO's OAuth token as the high-value credentials for automation. Security model is equivalent: one high-value secret per division on the VPS, protected by VPS access controls.
+- **Division-level attribution only (Phase 1)**: All LIMITLESS agents look identical in commit history (`limitless-agent[bot]`). Per-agent attribution is supplemented by `Authored-by-agent: PATHS Architect` commit footer convention until per-agent Apps are registered. This is sufficient for current LIMITLESS audit requirements (non-MiFID II).
+- **CEO's `GH_TOKEN` remains on host**: The CEO's personal token stays in the host `.env` for administrative operations (repo management, non-agent PRs, `gh` CLI admin tasks). This is unchanged from today.
+
+### Neutral
+
+- `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` trailer: retained unchanged in all agent commit messages.
+- CODEOWNERS: remains CEO-only for all repos. GitHub App bot users cannot be CODEOWNERS (they are synthetic accounts, not org members). No change to CODEOWNERS files.
+- Collaborating team members: their PRs are authored by their own human accounts. No intersection with the App token flow.
+
+---
+
+## Self-Correction Path
+
+If the GitHub App identity model fails in the future:
+
+| Failure mode | Recovery |
+|---|---|
+| Private key compromised | Immediately revoke in App settings. Generate replacement key (multiple keys supported — zero-downtime). Update `.env` on VPS. |
+| App installation suspended by GitHub | Activate Option A fallback (shared bot user account) within 1 hour. File remediation PR to update spec. |
+| GitHub changes `[bot]` attribution policy | `Co-Authored-By` and `Authored-by-agent:` commit footers provide secondary attribution record independent of GitHub's UI. |
+| VPS `.env` credential leak | Rotate both App private keys. Rotate CEO's `GH_TOKEN`. Audit commit history for any unauthorized pushes. |
+
+Full step-by-step recovery procedures: `docs/plans/agent-identity-rollout.md` §Recovery.
+
+---
+
+## Open Questions
+
+1. `[OPEN: Per-agent Apps for MYTHOS]` — At what point does MYTHOS require per-agent App registrations (e.g., distinguishing MYTHOS Architect from MYTHOS test-engineer in MiFID II records)? **Trigger**: when a second category of MYTHOS automation agent is deployed (Phase 2+ execution agents). **Decision owner**: CEO at that time.
+2. `[OPEN: LIMITLESS per-agent attribution]` — If per-app Architect attribution is required for LIMITLESS (not currently a requirement), register `limitless-paths-arch`, `limitless-cubes-arch`, etc. as additional Apps. **Decision owner**: CEO when requirement arises.
+3. `[RESOLVED: signed commits tooling]` — Squash merge via GitHub web UI satisfies the signed commits requirement on `main` via GitHub's automatic server-side signing. CEO local GPG/SSH configuration not required for branch protection. Recommended as best practice for CEO-authored commits (e.g., emergency direct merges) but not mandatory.
+
+---
+
+*This Decision Record is itself governed by the agentic SDLC governance spec. It must be ratified by CEO Approving Review before implementation begins.*

--- a/docs/plans/agent-identity-rollout.md
+++ b/docs/plans/agent-identity-rollout.md
@@ -1,0 +1,419 @@
+# Agent Identity Rollout Plan — DR-001 Implementation
+
+**Date**: 2026-04-19
+**Author**: Architect
+**Status**: Proposed — awaiting CEO ratification of DR-001 before execution
+**Implements**: `docs/decisions/DR-001-agent-identity-and-ratification-flow.md`
+**Operator**: CEO (`chmod735`) — all provisioning steps require org-owner access
+
+---
+
+## Prerequisites
+
+Before starting:
+- [ ] DR-001 has been ratified (CEO Approving Review on the PR that introduced this document)
+- [ ] NanoClaw engineer has been briefed on the container-runner changes required (separate handoff)
+- [ ] VPS SSH access confirmed
+- [ ] `gh` CLI authenticated as `chmod735` on the host machine
+
+---
+
+## Phase 1 — GitHub App Provisioning
+
+### Step 1.1 — Register `limitless-agent` GitHub App
+
+1. Navigate to: `https://github.com/organizations/LIMITLESS-LONGEVITY/settings/apps/new`
+2. Fill in App settings:
+   - **App name**: `limitless-agent`
+   - **Homepage URL**: `https://github.com/LIMITLESS-LONGEVITY`
+   - **Webhook**: Disabled (uncheck "Active")
+   - **Permissions** — Repository permissions only:
+     - Contents: **Read and write**
+     - Pull requests: **Read and write**
+     - Metadata: **Read** (auto-selected, read-only)
+     - Commit statuses: **Read and write** (for status checks, if needed)
+     - All others: **No access**
+   - **Where can this GitHub App be installed?**: Only on this account
+3. Click "Create GitHub App"
+4. Record the **App ID** (displayed on the App settings page). Store in plaintext as it is not a secret:
+   ```
+   LIMITLESS_APP_ID=<app-id>
+   ```
+5. Scroll to "Private keys" section → Click "Generate a private key"
+6. Download the `.pem` file. This is the high-value credential. **Do not commit it anywhere.**
+7. Copy the PEM content for storage in Step 2.
+
+### Step 1.2 — Register `mythos-agent` GitHub App
+
+Repeat Step 1.1 with:
+- **App name**: `mythos-agent`
+- Same permissions as above
+- Record `MYTHOS_APP_ID=<app-id>`
+- Download separate `.pem` private key
+
+### Step 1.3 — Install `limitless-agent` on `LIMITLESS-LONGEVITY/limitless`
+
+1. On the `limitless-agent` App settings page, click "Install App"
+2. Select organization: `LIMITLESS-LONGEVITY`
+3. Select "Only select repositories" → choose `LIMITLESS-LONGEVITY/limitless`
+4. Click "Install"
+5. Record the **Installation ID** from the URL after redirect (format: `https://github.com/organizations/LIMITLESS-LONGEVITY/settings/installations/<installation-id>`):
+   ```
+   LIMITLESS_APP_INSTALLATION_ID=<installation-id>
+   ```
+
+Alternatively via `gh` CLI (after installation):
+```bash
+gh api /app/installations --jq '.[] | select(.account.login == "LIMITLESS-LONGEVITY") | {id, account: .account.login}'
+```
+
+### Step 1.4 — Install `mythos-agent` on MYTHOS repos
+
+1. Install `mythos-agent` on `chmod735-dor/mythos`:
+   - Select org: `chmod735-dor` (or personal account if that's where the org lives)
+   - Select repos: `mythos` and `mythos-ops`
+   - Record installation ID as `MYTHOS_APP_INSTALLATION_ID=<installation-id>`
+
+### Step 1.5 — Retrieve Bot User IDs for git config
+
+GitHub App bot users have a numeric user ID required for the `user.email` in git config. Retrieve each:
+
+```bash
+# For limitless-agent
+gh api users/limitless-agent%5Bbot%5D --jq '{id, login}'
+# → {"id": 12345678, "login": "limitless-agent[bot]"}
+
+# For mythos-agent
+gh api users/mythos-agent%5Bbot%5D --jq '{id, login}'
+# → {"id": 87654321, "login": "mythos-agent[bot]"}
+```
+
+Record:
+```
+LIMITLESS_BOT_USER_ID=<id>
+MYTHOS_BOT_USER_ID=<id>
+```
+
+---
+
+## Phase 2 — VPS Credential Storage
+
+### Step 2.1 — Store credentials in NanoClaw `.env`
+
+On the VPS hosting NanoClaw for LIMITLESS, add to `/home/limitless/nanoclaw/.env`:
+
+```bash
+# GitHub App — limitless-agent
+LIMITLESS_APP_ID=<app-id>
+LIMITLESS_APP_INSTALLATION_ID=<installation-id>
+LIMITLESS_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+<pem-content-with-literal-newlines>
+-----END RSA PRIVATE KEY-----"
+
+# Bot user identity (for git config inside containers)
+LIMITLESS_BOT_USER_ID=<bot-user-id>
+
+# CEO's GH_TOKEN remains for administrative operations (non-agent PRs, repo management)
+GH_TOKEN=<ceo-token>
+```
+
+On the VPS hosting NanoClaw for MYTHOS, add to `/home/mythos/nanoclaw/.env` (or the MYTHOS-equivalent path):
+
+```bash
+# GitHub App — mythos-agent
+MYTHOS_APP_ID=<app-id>
+MYTHOS_APP_INSTALLATION_ID=<installation-id>
+MYTHOS_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+<pem-content-with-literal-newlines>
+-----END RSA PRIVATE KEY-----"
+
+# Bot user identity
+MYTHOS_BOT_USER_ID=<bot-user-id>
+
+# CEO's GH_TOKEN remains for admin operations
+GH_TOKEN=<ceo-token>
+```
+
+**Security requirements for `.env` file:**
+```bash
+chmod 600 /home/limitless/nanoclaw/.env
+chown limitless:limitless /home/limitless/nanoclaw/.env
+```
+
+The private key in the `.env` must have literal newlines preserved (not escaped `\n`). Test parsing with:
+```bash
+node -e "const k = process.env.LIMITLESS_APP_PRIVATE_KEY; console.log(k.startsWith('-----BEGIN'));"
+```
+
+### Step 2.2 — File permissions audit
+
+Verify `.env` is not readable by other users:
+```bash
+ls -la /home/limitless/nanoclaw/.env
+# Expected: -rw------- 1 limitless limitless ...
+```
+
+---
+
+## Phase 3 — NanoClaw Container-Runner Update
+
+This phase requires a separate engineer handoff. The Architect is not implementing code changes in this PR. The following describes what the implementation must achieve.
+
+### Required change: Token generation at container spawn time
+
+**Current flow** (container-runner.ts ~L268–270):
+```typescript
+if (process.env.GH_TOKEN) {
+  args.push('-e', `GH_TOKEN=${process.env.GH_TOKEN}`);
+  args.push('-e', `GITHUB_TOKEN=${process.env.GH_TOKEN}`);
+}
+```
+
+**Required flow** (pseudocode — engineer implements):
+```typescript
+// Generate GitHub App installation token (1-hour TTL)
+const appToken = await generateInstallationToken({
+  appId: process.env.LIMITLESS_APP_ID,           // or MYTHOS_APP_ID
+  installationId: process.env.LIMITLESS_APP_INSTALLATION_ID,
+  privateKey: process.env.LIMITLESS_APP_PRIVATE_KEY,
+});
+
+if (appToken) {
+  args.push('-e', `GH_TOKEN=${appToken}`);
+  args.push('-e', `GITHUB_TOKEN=${appToken}`);
+} else {
+  // Fallback: CEO token for non-agent containers or if App token generation fails
+  logger.warn('App token generation failed — falling back to GH_TOKEN');
+  if (process.env.GH_TOKEN) {
+    args.push('-e', `GH_TOKEN=${process.env.GH_TOKEN}`);
+    args.push('-e', `GITHUB_TOKEN=${process.env.GH_TOKEN}`);
+  }
+}
+```
+
+**Token generation function** (`generateInstallationToken`):
+
+The function must:
+1. Sign a JWT: `{ iss: APP_ID, iat: now - 60, exp: now + 540 }` signed with `RS256` using the private key
+2. POST to `https://api.github.com/app/installations/{INSTALLATION_ID}/access_tokens` with `Authorization: Bearer {jwt}`
+3. Parse and return `response.data.token`
+4. Cache the token until 55 minutes after generation (conservative margin before 60-minute expiry)
+5. On cache miss or expiry, regenerate
+
+**Library options** (engineer chooses based on existing dependencies):
+- `@octokit/auth-app` — purpose-built, handles JWT signing and token exchange
+- `jsonwebtoken` + `node-fetch` — manual implementation (more explicit, zero new dependencies if already present)
+
+**Git config injection** (required in settings.json or as `-e` args):
+```typescript
+// Must also be injected so git commits carry the correct bot identity
+const botUserId = process.env.LIMITLESS_BOT_USER_ID;  // e.g. "12345678"
+const botLogin  = 'limitless-agent[bot]';
+const botEmail  = `${botUserId}+${botLogin}@users.noreply.github.com`;
+
+// Inject into container settings.json env (alongside GH_TOKEN)
+mergedEnv['GIT_AUTHOR_NAME']    = botLogin;
+mergedEnv['GIT_AUTHOR_EMAIL']   = botEmail;
+mergedEnv['GIT_COMMITTER_NAME'] = botLogin;
+mergedEnv['GIT_COMMITTER_EMAIL']= botEmail;
+```
+
+The settings.json approach (writing into Claude Code's env config) ensures git uses the bot identity for all commits made inside the container. The `GIT_AUTHOR_*` and `GIT_COMMITTER_*` environment variables override any local `git config user.*` settings.
+
+**Scope**: This change applies to agent containers only (groups where `containerConfig?.envVars?.AGENT_ROLE` is set). Non-agent containers (e.g., direct CEO-operated sessions) retain the CEO's `GH_TOKEN`.
+
+**Engineer handoff reference**: Create a handoff to `#workbench-ops` or the appropriate app Architect after DR-001 is ratified. PR title for the implementation: `feat(nanoclaw): GitHub App installation token at container spawn (DR-001)`.
+
+---
+
+## Phase 4 — Git Configuration Verification
+
+After the container-runner update is deployed, verify inside a spawned agent container:
+
+```bash
+# Verify git identity resolves to the bot account
+git config user.name
+# Expected: limitless-agent[bot]
+
+git config user.email
+# Expected: 12345678+limitless-agent[bot]@users.noreply.github.com
+
+# Verify gh CLI is authenticated as the App bot (not the CEO)
+gh auth status
+# Expected: Logged in to github.com account limitless-agent[bot] (...)
+
+# Verify push works
+git checkout -b test/dr-001-identity-check
+echo "test" >> /tmp/test.txt
+git add /tmp/test.txt
+git commit -m "chore: DR-001 identity verification test"
+git push origin test/dr-001-identity-check
+# → Should succeed; commit author should show as limitless-agent[bot] on GitHub
+
+# Create a test PR
+gh pr create --title "chore: DR-001 identity verification" --body "Test PR — delete after verification" --draft
+# → PR author should show as limitless-agent[bot] in GitHub UI
+
+# CEO navigates to the PR and clicks "Approve"
+# → Should succeed without self-approval error
+
+# Verify: CEO merges the test PR
+# Clean up: delete the test branch
+git push origin --delete test/dr-001-identity-check
+```
+
+**Expected results:**
+- [ ] `git config user.name` returns `limitless-agent[bot]`
+- [ ] `git config user.email` returns `{bot-user-id}+limitless-agent[bot]@users.noreply.github.com`
+- [ ] `gh auth status` shows `limitless-agent[bot]` (not `chmod735`)
+- [ ] GitHub PR author field shows `limitless-agent[bot]`
+- [ ] CEO can submit Approving Review on the test PR
+- [ ] Squash merge commit on `main` shows "Verified" badge (GitHub-signed server-side)
+
+---
+
+## Phase 5 — CODEOWNERS and PR Template Updates
+
+### Step 5.1 — Update CODEOWNERS comments (no functional change)
+
+In `LIMITLESS-LONGEVITY/limitless/.github/CODEOWNERS`, update the agent note:
+```
+# Note: AI Architect agents operate as limitless-agent[bot] (GitHub App bot user)
+# and cannot be CODEOWNERS. Human CEO (chmod735) is the required approver. See DR-001.
+```
+
+In `chmod735-dor/mythos/.github/CODEOWNERS`:
+```
+# Note: MYTHOS Architect operates as mythos-agent[bot] (GitHub App bot user)
+# and cannot be CODEOWNERS. CEO required for all paths. See DR-001.
+```
+
+### Step 5.2 — Update PR templates (no functional change)
+
+Replace the footer `🤖 Agent-authored — human ratification required before merge.` with:
+```
+🤖 Authored by `limitless-agent[bot]` — human ratification required before merge. See DR-001.
+```
+(or `mythos-agent[bot]` for MYTHOS repos)
+
+---
+
+## Phase 6 — Retention Export Update
+
+### Step 6.1 — Update export cron to use CEO's token for gh API calls
+
+The weekly/daily retention export cron (`gh api` calls for PR history) must continue to use the CEO's `GH_TOKEN`, not the App token. The App token is scoped to `contents: write` and `pull-requests: write` — sufficient for pushing and creating PRs, but the retention export requires read access to historical PRs with full body content.
+
+No change required to the export cron if it runs with the CEO's `GH_TOKEN` (which it does today). Verify:
+```bash
+# Confirm export cron uses GH_TOKEN (CEO) not app token
+grep GH_TOKEN /path/to/retention-export.sh
+# Should reference ${GH_TOKEN} or equivalent CEO token
+```
+
+---
+
+## Phase 7 — Rollout Sequencing
+
+Apply in this order:
+
+| Step | Action | Verifiable? | Rollback? |
+|---|---|---|---|
+| 1 | Register GitHub Apps (Steps 1.1–1.2) | ✅ App settings page | Delete App |
+| 2 | Install Apps on repos (Steps 1.3–1.4) | ✅ `gh api /app/installations` | Uninstall App |
+| 3 | Retrieve bot user IDs (Step 1.5) | ✅ `gh api users/...` | N/A (read-only) |
+| 4 | Add credentials to VPS `.env` (Phase 2) | ✅ `node -e` parse test | Remove env vars |
+| 5 | Deploy container-runner update (Phase 3) | ✅ Via dedicated engineer PR | Revert the PR |
+| 6 | Verify identity flow in container (Phase 4) | ✅ Explicit checklist | Revert engineer PR |
+| 7 | Update CODEOWNERS comments (Phase 5) | ✅ File diff | Revert PR |
+| 8 | Update PR templates (Phase 5) | ✅ File diff | Revert PR |
+| 9 | Confirm retention export unaffected (Phase 6) | ✅ Manual run | N/A (read-only) |
+
+**Do not proceed to Step 5 (container-runner deployment) until Steps 1–4 are fully verified.** If the App token is injected but not correctly generated, agents will have no GitHub authentication and all git operations will fail.
+
+---
+
+## Token Rotation Procedure
+
+### App private key rotation (recommended: annually or on key compromise)
+
+```bash
+# 1. Generate a NEW private key (do not delete the old one yet)
+# GitHub: App Settings → Private keys → Generate a private key
+# Download the new .pem file
+
+# 2. Add new key to .env (temporarily have both old and new)
+LIMITLESS_APP_PRIVATE_KEY_NEW="-----BEGIN RSA PRIVATE KEY-----
+<new-pem-content>
+-----END RSA PRIVATE KEY-----"
+
+# 3. Update NanoClaw to use new key variable (or swap the value of LIMITLESS_APP_PRIVATE_KEY)
+# Restart NanoClaw service
+systemctl restart nanoclaw-limitless.service
+
+# 4. Verify new key works (spawn a test container, confirm git push succeeds)
+
+# 5. Delete old key from GitHub App settings
+# GitHub: App Settings → Private keys → Delete old key
+
+# 6. Remove LIMITLESS_APP_PRIVATE_KEY_NEW from .env; LIMITLESS_APP_PRIVATE_KEY now holds the new value
+```
+
+Multiple private keys can be active simultaneously on a GitHub App — this enables zero-downtime rotation.
+
+### Installation token (no manual rotation)
+
+Installation tokens expire automatically after 1 hour. NanoClaw generates a fresh token at each container spawn. No manual rotation required.
+
+---
+
+## Recovery Procedure
+
+### Scenario 1: Private key compromised
+
+1. Immediately revoke the compromised key in GitHub App settings (App → Private keys → Delete)
+2. Generate a replacement private key
+3. Update VPS `.env` with new key
+4. Restart NanoClaw service
+5. Verify token generation works in test container
+6. Audit GitHub's org audit log for any unauthorized pushes during the exposure window
+
+### Scenario 2: GitHub App suspended or deleted
+
+1. Activate Option A fallback immediately:
+   - Create `limitless-agent-bot` machine user account (CEO creates, using a separate email)
+   - Generate fine-grained PAT with `contents: write`, `pull-requests: write`
+   - Submit PAT for org-owner approval (required for fine-grained PATs)
+   - Update VPS `.env`: `GH_TOKEN_AGENT=<bot-pat>` (separate from CEO's `GH_TOKEN`)
+   - Update container-runner to inject `GH_TOKEN_AGENT` for agent containers
+2. File a governance amendment PR noting the identity model change
+3. Investigate the cause of App suspension and remediate before re-registering the App
+
+### Scenario 3: GitHub changes `[bot]` attribution policy
+
+1. Assess impact on MiFID II audit trail (consult legal if needed)
+2. The `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` trailer remains as a secondary attribution record in all commit messages — independent of GitHub's UI-layer attribution
+3. Consider adding `Authored-by-agent: {agent-name}` as a mandatory commit footer for all agent commits (this is a commit message convention, independent of GitHub's identity system)
+4. File a governance amendment PR
+
+### Scenario 4: VPS `.env` credential leak
+
+1. Immediately rotate: App private key(s), CEO `GH_TOKEN`
+2. Audit org audit log for unauthorized pushes, PR creations, or repo access
+3. Review which commits were pushed during the exposure window
+4. For MYTHOS: notify MiFID II compliance function if any regulated algorithm changes may have been tampered with
+
+---
+
+## Ongoing Monitoring
+
+After rollout, verify monthly:
+- [ ] App installation still active: `gh api /app/installations`
+- [ ] Bot user IDs unchanged (stable after initial assignment)
+- [ ] Agent PRs showing `limitless-agent[bot]` / `mythos-agent[bot]` in author field
+- [ ] CEO can still submit Approving Reviews on agent PRs
+- [ ] No `GH_TOKEN` (CEO token) leaking into agent container logs
+
+---
+
+*This plan is plan-only. No implementation begins until DR-001 is ratified and CEO explicitly authorizes rollout.*

--- a/docs/superpowers/specs/2026-04-18-agentic-sdlc-governance.md
+++ b/docs/superpowers/specs/2026-04-18-agentic-sdlc-governance.md
@@ -1,7 +1,9 @@
 # Agentic SDLC Governance & Workflow
 
 **Date**: 2026-04-18
-**Amended**: 2026-04-19 (v1.2 — DR-002 findings: NanoClaw deploy pipeline established; DR-001 Phase 3 landing target clarified; Agent Vault confirmed non-replacement; see DR-002)
+**Amended**:
+- 2026-04-19 (v1.1 — agent identity model; see DR-001)
+- 2026-04-19 (v1.2 — DR-002 findings: NanoClaw deploy pipeline established; DR-001 Phase 3 landing target clarified; Agent Vault confirmed non-replacement; see DR-002)
 **Author**: Architect
 **Status**: Proposed — awaiting CEO ratification
 **Applies to**: `LIMITLESS-LONGEVITY/limitless` · `chmod735-dor/mythos` · `chmod735-dor/mythos-ops` · all future repos under this division
@@ -150,13 +152,15 @@ infra/                @<CEO-github-handle>
 docs/                 @<CEO-github-handle>
 ```
 
-Note: Architect agents are not GitHub users and cannot be CODEOWNERS. Human CEO is the required approver.
+Note: Architect agents operate as GitHub App bot users (`limitless-agent[bot]`) and cannot be CODEOWNERS. Human CEO (`chmod735`) is the required approver. See DR-001.
 
 ### 4.2 `chmod735-dor/mythos` — `.github/CODEOWNERS`
 
 ```
 # MYTHOS — CODEOWNERS
 # CEO required for all paths.
+# Note: MYTHOS Architect operates as mythos-agent[bot] (GitHub App bot user)
+# and cannot be CODEOWNERS. See DR-001.
 * @<CEO-github-handle>
 
 # Safety-critical paths — CEO required + safety reviewer when designated
@@ -191,12 +195,14 @@ External team members can be added as CODEOWNERS for specific subtrees (e.g. `si
 A MYTHOS PR is **ratified** when ALL of the following are true at merge time:
 
 1. All checkboxes in the PR body ratification checklist are ticked
-2. CEO has submitted a GitHub Approving Review (not just a comment)
+2. CEO has submitted a GitHub **Approving Review** (not just a comment). This is achievable because agent PRs are authored by `mythos-agent[bot]` (a GitHub App bot identity distinct from the CEO's human account `chmod735`). GitHub's self-approval restriction does not apply — `chmod735` approving `mythos-agent[bot]`'s PR is the standard human-ratifies-automation flow. See DR-001.
 3. The review body contains the word `RATIFIED` or `Approved` explicitly
 4. All required status checks have passed
 5. No unresolved review conversations remain
 
 The merge commit then carries: timestamp (UTC), merge author (CEO GitHub handle), PR number, PR title, and a link to the full PR body including the ratification checklist. This constitutes a durable, attributable, timestamped record.
+
+> **v1.0 workaround retired**: Prior to agent identity implementation (DR-001), a Comment-type review with `RATIFIED` keyword was used as an interim measure because agents pushed as the CEO's GitHub account. This workaround is retired once DR-001 rollout is complete. All future ratifications must use a formal Approving Review (condition #2 above).
 
 ### 5.2 Standard ratification checklist (all MYTHOS PRs)
 
@@ -388,7 +394,27 @@ PR templates live at `.github/pull_request_template.md` in each repo. They are c
 
 All commits follow **Conventional Commits v1.0.0** (https://www.conventionalcommits.org/).
 
-### Format
+### 8.1 Commit attribution hierarchy (v1.1)
+
+Every agent-authored commit carries three layers of attribution:
+
+| Layer | What it records | Where it appears |
+|---|---|---|
+| **GitHub author** | `limitless-agent[bot]` or `mythos-agent[bot]` — the NanoClaw agent system that pushed | Commit history, PR author field, org audit log |
+| **AI model** | `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` — the underlying model that generated the content | Commit message footer |
+| **Ratifier** | `chmod735` (CEO) — the human who reviewed and squash-merged | Squash merge commit author; PR "Approved by" field |
+
+The `Co-Authored-By` trailer is retained from v1 and must not be removed. It provides AI model-level attribution that is independent of GitHub's identity system and persists in the commit message regardless of any future changes to GitHub's `[bot]` attribution policy.
+
+For per-agent attribution within a division (since all LIMITLESS agents share `limitless-agent[bot]`), include an `Authored-by-agent:` footer in the commit message body:
+
+```
+Authored-by-agent: PATHS Architect
+```
+
+This is optional for LIMITLESS (non-MiFID II) and recommended for MYTHOS (MiFID II attribution).
+
+### 8.2 Format
 
 ```
 type(scope): subject line ≤72 chars
@@ -397,17 +423,19 @@ Body: what and why (not how). Wrap at 72 chars.
 Multiple paragraphs allowed.
 
 Footer:
+Authored-by-agent: <Agent name>
 ROADMAP-REF: P1-INFRA-001
 Reviewed-by: CEO
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 ```
 
-### Rules
+### 8.3 Rules
 
 1. Subject line: imperative mood ("add gate" not "added gate"), ≤72 chars, no trailing period
 2. Breaking changes: append `!` to type (`feat!`) and include `BREAKING CHANGE:` in footer
 3. Agent attribution: always include `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` (or the model used)
-4. Squash commits on merge: the squash commit message = PR title (already Conventional Commits) + PR body as extended description
+4. Per-agent attribution: include `Authored-by-agent: <name>` in footer (required for MYTHOS, recommended for LIMITLESS)
+5. Squash commits on merge: the squash commit message = PR title (already Conventional Commits) + PR body as extended description
 
 ---
 
@@ -478,8 +506,8 @@ External collaborators operate as **contributors**: they submit PRs, carry requi
 
 | Role | Can author PRs | Required reviewer for subtree | Can merge | Can approve (non-blocking) |
 |------|---------------|-------------------------------|-----------|---------------------------|
-| CEO | ✅ | ✅ (all paths) | ✅ | ✅ |
-| AI Architect | ✅ | ❌ (not a GitHub user) | ❌ | ❌ |
+| CEO (`chmod735`) | ✅ | ✅ (all paths) | ✅ | ✅ |
+| AI Architect (GitHub App bot: `limitless-agent[bot]` / `mythos-agent[bot]`) | ✅ | ❌ (bot users cannot be CODEOWNERS) | ❌ | ❌ |
 | Collaborating team lead | ✅ | ✅ (their subtree) | ❌ | ✅ |
 | Collaborating team member | ✅ | ❌ | ❌ | ✅ |
 
@@ -492,7 +520,7 @@ External collaborators operate as **contributors**: they submit PRs, carry requi
 
 ### 11.3 CEO single-approver scale
 
-**Current state (Phase 1)**: CEO as sole approver is appropriate. All PRs are authored by AI agents; the review burden is ratification of agent output, not peer code review. Volume is manageable (1–3 PRs/day estimated in Phase 1).
+**Current state (Phase 1)**: CEO as sole approver is appropriate. All PRs are authored by AI agents (`limitless-agent[bot]` / `mythos-agent[bot]`); the review burden is ratification of agent output, not peer code review. The author ≠ approver invariant is maintained by the GitHub App identity model (DR-001). Volume is manageable (1–3 PRs/day estimated in Phase 1).
 
 **Scale-up trigger**: When Execution layer implementation begins (Phase 3), designate a **Safety Reviewer** with domain expertise in quantitative trading systems. This person becomes a required reviewer specifically for `engine/gates/`, `engine/ibkr/`, and `db/migrations/`. CEO retains merge authority.
 
@@ -564,7 +592,7 @@ Apply in this order. Do NOT skip steps. Each step is independently verifiable.
 
 1. `[OPEN: legal review before Phase 4]` — Whether a formal DPA with GitHub is required for MiFID II record-keeping. Low risk for single-operator account; legal review before live trading.
 2. `[OPEN: Safety Reviewer designation]` — Designate by Phase 3 kick-off. External quantitative trading / regulatory expert preferred.
-3. `[OPEN: signed commits tooling]` — CEO must configure GPG/SSH commit signing before MYTHOS branch protection Step 1.4 is activated. Requires: `git config --global user.signingkey <key>` and `git config --global commit.gpgsign true`. *Note: v1.1 (PR #60) partially resolves this — squash merges on `main` are GitHub-signed automatically. Local signing remains recommended for CEO-authored direct commits.*
+3. `[RESOLVED: signed commits tooling — v1.1]` — The "Require signed commits" ruleset on `main` applies to commits pushed *to* `main`. Agents push to PR branches, not `main`. The squash merge commit on `main` is created server-side by GitHub when the CEO clicks "Squash and merge" via the web UI — GitHub automatically signs this commit, producing a "Verified" badge without any CEO local GPG/SSH configuration. CEO local signing is recommended as best practice for CEO-authored commits (e.g., emergency direct merges per §1.2 mythos-ops exception) but is not required for branch protection to function. See DR-001 Option C rationale.
 4. `[OPEN: PR #1 on chmod735-dor/mythos]` — Confirm whether PR #1 is open. If so, apply grandfather clause per DQ4 before activating branch protection.
 5. `[OPEN: DR-001 Phase 3 implementation — v1.2]` — DR-001 Phase 3 (GitHub App installation token in container-runner) is **unblocked by DR-002 Phase 4** (VPS migration to monorepo clone + deploy pipeline). Landing target: `apps/nanoclaw/src/container-runner.ts`. Deployment: GitHub Actions pipeline (DR-002). Implementation PR title: `feat(nanoclaw): GitHub App installation token at container spawn (DR-001 Phase 3)`. File this handoff after DR-002 is ratified and DR-002 Phases 1–4 are complete.
 6. `[OPEN: MYTHOS OneCLI provisioning — v1.2]` — After DR-002 Phase 4 (MYTHOS VPS on git clone), provision a dedicated OneCLI instance for the `mythos` VPS user (DR-002 Phase 5). Once live, the `CLAUDE_CODE_OAUTH_TOKEN` direct injection from PR #53 is replaced by OneCLI credential routing. See `docs/plans/nanoclaw-source-of-truth-rollout.md` §Phase 5. The PR #53 direct injection remains valid as interim until OneCLI is live.


### PR DESCRIPTION
## Summary

- **Gap identified**: Governance spec v1 §5.1 requires a formal GitHub Approving Review for MiFID II ratification. In practice, agents push as the CEO's GitHub account (`chmod735`), triggering GitHub's self-approval block — making §5.1 condition #2 structurally unreachable.
- **Root cause**: NanoClaw injects `GH_TOKEN=${CEO_TOKEN}` into all agent containers. Agent identity is conflated with human CEO identity. This is a category error: agents are not humans.
- **Decision (DR-001)**: Adopt GitHub Apps as the canonical agent identity mechanism. Two Apps — `limitless-agent` (LIMITLESS) and `mythos-agent` (MYTHOS) — produce `[bot]` identities that are categorically distinct from the CEO's account. CEO can formally Approve agent PRs. §5.1 is restored.

## Deliverables

| File | Description |
|---|---|
| `docs/decisions/DR-001-agent-identity-and-ratification-flow.md` | Decision Record — context, four options evaluated, chosen option, rationale, consequences, self-correction path |
| `docs/superpowers/specs/2026-04-18-agentic-sdlc-governance.md` | Spec amended to v1.1 — §5.1 fixed, §8 attribution hierarchy added, §11.1 agent role updated, open questions updated |
| `docs/plans/agent-identity-rollout.md` | Step-by-step implementation plan — App provisioning, VPS credential storage, container-runner change spec, verification checklist, token rotation, recovery procedures |

## Change class

- [x] Decision Record
- [x] Governance / spec docs

## ROADMAP reference

N/A — governance infrastructure

## Test evidence

N/A — planning deliverables only. Implementation is gated on CEO ratification of DR-001. No code is changed in this PR.

## Ratification

**⚠️ CEO: check all boxes before merging.**

- [ ] I have read DR-001, the spec v1.1 diff, and the rollout plan in full
- [ ] The chosen option (GitHub Apps, Option C) is understood and approved
- [ ] The rollout plan correctly reflects the provisioning steps you will execute
- [ ] The governance spec v1.1 amendments are accurate and complete
- [ ] No open questions silently assumed (all flagged as `[OPEN]` or resolved)
- [ ] Sovereignty constraint: no cloud inference on live-trading hot path *(N/A — no code changes)*
- [ ] Safety gates non-overridable by any AI output *(N/A — no code changes)*
- [ ] Regulatory posture: Ireland / EU — MiFID II *(confirmed — v1.1 improves MiFID II attribution clarity)*
- [ ] Audit retention: 7-year plan not undermined *(confirmed — `[bot]` attribution in PR history is durable)*

🤖 Agent-authored — human ratification required before merge.

---

**Implementation note**: This PR ratifies the design. The actual container-runner change (generating installation tokens at spawn time) requires a separate engineer handoff after ratification. The Comment-type review workaround for §5.1 remains in effect until that implementation PR is merged and deployed.