### PR TITLE
docs(sdlc): Phase 2 readiness dispatch artifacts

### DIFF
--- a/docs/plans/2026-04-21-architect-handoff-phase-2-questions.md
+++ b/docs/plans/2026-04-21-architect-handoff-phase-2-questions.md
@@ -1,0 +1,275 @@
+# Architect Handoff — CEO Questions on Phase 2 Readiness Report
+
+**Date filed:** 2026-04-21
+**Filed by:** Director (on CEO directive)
+**Target agent:** LIMITLESS main-ops Architect (#main-ops)
+**Status:** DRAFT — awaiting CEO approval before Discord dispatch
+**Expected deliverable:** single ratifiable PR against `LIMITLESS-LONGEVITY/limitless` with governance/plan docs that answer all four topics
+**Do NOT implement code changes.** This handoff is research + analysis + proposal only.
+
+---
+
+## Context the Architect needs
+
+On 2026-04-21 the Director produced `docs/superpowers/specs/2026-04-21-agentic-sdlc-phase-2-readiness-report.md` — a comprehensive framework status report ahead of onboarding the MYTHOS collaborator `@aradSmith`. The CEO reviewed the report and wrote a response in `docs/superpowers/specs/SDLC phase 2 readiness report questions.md` raising four categories of concerns that the readiness report did NOT address (or addressed only superficially).
+
+Before the CEO greenlights Phase 2 (active co-development with a second human), these four gaps must be closed. Each one is a request for **research → gap analysis → proposal**, not implementation. Every deliverable below is a document that the CEO ratifies by squash-merging a PR.
+
+**Framework reminders:**
+- Governance spec v1.2 is on main: `docs/superpowers/specs/2026-04-18-agentic-sdlc-governance.md`
+- DR-001 (agent identity) and DR-002 (NanoClaw SoT) ratified — see `docs/decisions/`
+- DR-001 Phase 3 is the only unresolved audit gap; interim workaround (Comment-review + `RATIFIED`) still active
+- All 3 repos have CODEOWNERS + PR templates. Branch protection not yet applied by design.
+- Per-app Architect scope model: each Architect owns ONE app deeply (see `2026-04-05-division-v2-federated-architecture.md`)
+
+**Relevant project memory (summarised for the Architect):**
+- Director-vs-Architect comparison experiment was run on 2026-04-04 for MYTHOS docs: Architect produced implementation-ready 1,260 lines (scored 8.5/10); Director produced 507-line overview (scored 7/10). Factor this prior result into Topic 2's methodology — don't rerun it, build on it.
+- OpenClaw Director currently runs `openai-codex/gpt-5.4` via ChatGPT Plus subscription OAuth JWT (switched 2026-04-18 from `openai/gpt-4o` API key). This model choice affects Topic 2's assessment.
+- GitLab+Jira adoption impact assessment already landed as PR #54 on 2026-04-21 — start from that document; don't duplicate the research.
+
+---
+
+## Output contract (what "done" looks like)
+
+Deliver ONE PR that includes the following files. Each file answers one topic end-to-end. Do not split into multiple PRs — the CEO wants to ratify this as a single review pass.
+
+| Topic | File to author | Approximate length |
+|---|---|---|
+| 1 — Agent setup + config process | `docs/superpowers/specs/2026-04-XX-agent-config-governance.md` | Medium (spec with process + file inventory + versioning proposal) |
+| 2 — OpenClaw Director validation | `docs/plans/2026-04-XX-director-validation-plan.md` | Long (structured stress-test plan + gate criteria) |
+| 3 — PM system for the agentic SDLC | `docs/superpowers/specs/2026-04-XX-pm-system-selection.md` | Long (options analysis + recommendation) |
+| 5 — Human-friendly onboarding documentation roadmap | `docs/plans/2026-04-XX-human-onboarding-docs-roadmap.md` | Short-to-medium (roadmap of future PRs, not the docs themselves) |
+
+Substitute the real date when filing. Use the PR template already on main.
+
+PR title (proposed): `docs: Phase 2 readiness — agent config governance + Director validation + PM system + onboarding docs roadmap`
+
+Include a combined ratification checklist at the bottom of the PR body — CEO wants to approve the whole set atomically.
+
+Do NOT make any changes outside `docs/`. Do NOT touch `apps/nanoclaw/`, `infra/`, or CI workflows in this PR.
+
+---
+
+## Topic 1 — Agent Setup and Config: Process, Inventory, Versioning
+
+### What the CEO asked
+
+> How were the different settings for the Architects arrived at? What process led to our method of setting up an agent like the Architect? What have we based our different md files for each agent on? Was it specific to Anthropic models? Was it model-agnostic? Did we put in comparison metrics to figure out what works best? Did we make sure this process is ongoing since agents' setup and config is an evolving process that is also tied to new model releases (as well as changes made to coding harnesses and other relevant tech)? Did we codify this process so it too is versioned and auditable and is constantly updated and evolved? Do we have a system to track all the files determining the settings of each agent (e.g. Architect, workers, sub-agents, etc.)? Which files in our documentation document all the above topics?
+
+### What the deliverable must contain
+
+1. **Current-state audit (evidence-based; cite files):**
+   - Inventory every file that influences Architect/agent behavior. At minimum investigate: `apps/nanoclaw/groups/discord_{app}-eng/CLAUDE.md` (all 5), `apps/nanoclaw/src/config.ts`, `apps/nanoclaw/src/container-runner.ts` (env injection), the system prompts baked into Claude Code itself, `settings.json` per agent, OpenClaw `SOUL.md` / `IDENTITY.md` / `USER.md` / `TOOLS.md` / `HEARTBEAT.md` / `MEMORY.md`, and any `.env` values that affect agent capabilities (ANTHROPIC_MODEL, MAX_THINKING_TOKENS, TRUSTED_BOT_IDS, etc.). The Architect has read access to the monorepo — read them.
+   - For each file: what does it control, who authored the current contents, what (if any) rationale is documented for specific settings choices.
+   - Describe the actual historical process that produced each file — was it iterative ad-hoc tuning, was it benchmark-driven, was it copied from a reference, was it CEO-dictated?
+   - Explicitly answer: model-specific vs model-agnostic. Cite evidence.
+   - Explicitly answer: were comparison metrics used? Where are those metric records? If none exist, say so clearly.
+
+2. **Gap analysis:**
+   - What's missing for a system that can evolve with each model release (Claude 4.7 → 4.8 → 5.0; Opus → Sonnet → Haiku rebalancing; thinking-tokens defaults; prompt-caching behavior; Agent SDK version bumps; Claude Code harness updates).
+   - What's missing for harness-side evolution (e.g., Claude Code feature releases, new skills, hook-system changes).
+   - What's missing for reproducibility — if someone has to recreate an Architect from scratch tomorrow, what doesn't exist?
+
+3. **Proposed ongoing governance process:**
+   - A versioned, auditable workflow for reviewing/updating agent configuration on a cadence (e.g., quarterly and on every major model release).
+   - A proposed **Agent Configuration Registry** — structured file inventory (machine-readable where possible; YAML/JSON manifest listing every agent, the files that define it, the model, thinking budget, tools, mounts, and last-reviewed date) living in `docs/` or `apps/nanoclaw/agents/`.
+   - A proposed **Decision Record pattern** for config changes (parallel to DR-001/DR-002 — e.g., "DR-CFG-NNN: change Architect X from model Y to model Z, rationale, benchmark evidence").
+   - A proposed **benchmarking protocol** — concrete task suite the Architect runs on every model/harness upgrade to catch regressions. Start with 3–5 representative tasks per Architect; ratchet up later.
+   - Integration with the existing governance spec — does this become §13 of the spec, or a standalone DR, or its own spec document? Recommend one and justify.
+
+4. **Documentation index:**
+   - Explicit map of which existing docs touch this topic today (likely: governance spec §8 attribution, `project_agentic_infrastructure.md` memory file, individual CLAUDE.md files) and which ones need to be created.
+
+### Non-goals for Topic 1
+
+- Do not change any agent configuration in this PR. This is a meta-governance deliverable.
+- Do not benchmark models right now. Propose the protocol; the benchmarks run as a follow-up handoff.
+
+---
+
+## Topic 2 — OpenClaw Director Validation Before Workflow Integration
+
+### What the CEO asked
+
+> The Director is currently not integrated into our workflow. While we have set it up in practice, the current workflow is Human CEO → NanoClaw Architect. This is a pre-governance-spec habit. Before we start using the Director as per our new specs we need to make sure it is indeed up to the task. The NanoClaw Architect has a proven track record (tested multiple times by comparing its work to Claude Code Opus 4.6 / 4.7 running on the local dev machine). The same has NOT been done for the Director. Before integration we must (a) answer the same questions from Topic 1 applied to the Director, and (b) stress-test and peer-review its performance using the same methodology.
+
+### What the deliverable must contain
+
+1. **Current Director state audit (parallel to Topic 1):**
+   - All OpenClaw Director configuration files: `SOUL.md`, `IDENTITY.md`, `USER.md`, `TOOLS.md`, `HEARTBEAT.md`, `MEMORY.md` on VPS-1 at `/home/limitless/.openclaw/workspace/`. Ask the CEO to paste the current contents via Discord if the Architect cannot read them directly through its mounts.
+   - Gateway config: agent bindings (`agents add`, `agents bind`), channel allowlist, `allowBots: true`, `requireMention: false`, `models.providers.openai-codex` setup, `controlUi.dangerouslyAllowHostHeaderOriginFallback: true`.
+   - Current LLM: `openai-codex/gpt-5.4` via ChatGPT Plus subscription OAuth JWT (auth source: `~/.codex/auth.json`). NOT an API-key flow — specifically a Codex Responses API flow that requires JWT with `chatgpt_account_id`.
+   - Document the same process-origin question: how were these settings arrived at, and by whom.
+
+2. **Stress-test + peer-review plan:**
+   - A concrete list of representative tasks the Director should be asked to perform end-to-end, matching how we tested the Architect. Suggested categories:
+     - Decomposition: given a vague CEO goal ("ship Garmin integration by June"), break into app-level tasks and dispatch to the correct Architect channels.
+     - Cross-app coordination: given a merged PR with an API-contract change, identify downstream affected apps and post follow-up dispatches.
+     - Memory discipline: over multiple days, does MEMORY.md remain coherent and not self-contradict?
+     - Escalation behavior: when an Architect reports failure, does the Director escalate appropriately (retry with more context, route to different Architect, page the CEO)?
+     - Cron-driven maintenance: daily briefing, health check, PR triage — does it actually fire and produce useful output, or cause alert fatigue?
+   - For each task: a success criterion the Architect can judge objectively, plus a side-by-side comparison with how a Claude Code local Opus 4.7 session would have handled the same prompt.
+   - Explicit reference to the 2026-04-04 MYTHOS docs experiment (Architect 8.5/10 vs Director 7/10) — factor that prior result into the new protocol; don't repeat it verbatim.
+
+3. **Model choice re-examination:**
+   - Given the current `openai-codex/gpt-5.4` configuration, is that the right model for the Director role? Compare characteristics: persistence, cost (ChatGPT Plus subscription is flat-rate), reasoning depth on decomposition tasks, multi-channel orchestration quality. Would a Claude Opus 4.7 or Sonnet 4.6 configuration perform better? Would it be cheaper to use different models for different Director sub-tasks (decomposition vs routine cron work)? Propose a recommendation.
+   - If a model change is proposed, call out the Codex-CLI-subprocess gotcha: setting `OPENAI_API_KEY` in the gateway env causes Codex CLI to auto-revert `auth.json` to apikey mode, disabling subscription billing. Any reconfiguration must preserve the OAuth-JWT path.
+
+4. **Gate criteria for integration:**
+   - A crisp checklist the CEO can evaluate before flipping from "Human CEO → NanoClaw Architect (current)" to "Human CEO → Director → NanoClaw Architect (new spec)".
+   - Must include: which behaviors are must-pass (no regressions on representative decomposition tasks) and which are nice-to-have (auto cross-app coordination per §5 of v2 spec).
+   - Must specify rollback procedure if Director performs worse than direct CEO → Architect dispatch.
+
+### Non-goals for Topic 2
+
+- Do not execute the stress tests in this PR. Propose them; the CEO decides when to run them.
+- Do not change OpenClaw config. Propose changes as separate follow-up DRs.
+
+---
+
+## Topic 3 — Project Management System for the Agentic SDLC
+
+### What the CEO asked
+
+> Are we using Jira? If so how? Are humans (Director, Architect-human-in-loop) opening Jira tickets for agents and do agents use Jira themselves? If we're not using Jira what are we using instead? Is the human only using Discord + GitHub to replace the whole Jira workflow? Will this be enough for complex development projects?
+>
+> Context: Agentic SDD treats specs as executable artifacts and "version control for your thinking." Spec is the code; velocity negates rigidity; recursive iteration on architecture not source. We're moving from Vibe Coding to Architectural Determinism where the developer role shifts from line-by-line implementer to high-level system orchestrator. The question is how our agentic SDLC integrates the components of the pre-agentic SDLC into it.
+
+### What the deliverable must contain
+
+1. **Current state audit:**
+   - Are we using Jira right now? Answer: likely NO beyond the `JIRA: MYTHOS-47` convention reserved in governance spec §6.3 — confirm this.
+   - Read PR #54 (`docs(specs): GitLab + Jira adoption impact assessment for MYTHOS`) merged 2026-04-21 — this is directly relevant. Summarize its findings and build on them (don't duplicate).
+   - Inventory what we actually use today as a PM surface: Discord channels (#main-ops, #handoffs, #workers, #humans, #paths-eng, #cubes-eng, #hub-eng, #dt-eng, #infra-eng, #mythos-eng), GitHub Issues (if any), GitHub Projects, `docs/plans/`, `docs/superpowers/specs/`. Identify which artifact types we use for which PM function (task intake, prioritization, sprint planning, retro, dependency tracking, cross-team visibility).
+
+2. **Framing — integrate, don't transplant:**
+   - The CEO's framing is correct: the pre-agentic SDLC had phases (requirements → design → implementation → test → deploy) each mapped to Jira ticket types + workflows. In an agentic SDLC, the implementation phase is a runtime execution (minutes). The bottleneck is architecture and intent.
+   - Produce a table mapping each traditional PM function to: (a) what the agentic flow actually needs, (b) what artifact carries it in our stack today, (c) where the gap is.
+
+3. **Options analysis:**
+   - **Option A — Jira (or Linear equivalent):** full Agile stack, human-first UI, requires agents to have Jira API access + convention enforcement. Pro: familiar to incoming human collaborators. Con: agents doing ticket hygiene is operationally expensive and can drift from the PR reality.
+   - **Option B — GitHub-native (Issues + Projects + Milestones):** use GitHub's built-in surface. Pro: single-pane-of-glass with code + PRs + CI; no extra auth; MiFID II audit already lives here. Con: weaker on cross-repo dependency graphs and sprint mechanics.
+   - **Option C — Spec-as-source-of-truth (Spec-Driven Development):** specs in `docs/superpowers/specs/` + DRs are the primary artifact; PRs implement them; tickets don't exist. Pro: matches the CEO's SDD framing; spec is the code. Con: weaker visibility for humans who think in ticket queues; needs something to surface what's "active" vs "done".
+   - **Option D — Hybrid:** GitHub Issues/Projects as a lightweight ticket surface + specs-as-SoT for *content* + Discord as dispatch bus. Each surface has a narrow role.
+   - Evaluate all four against: human-collaborator ergonomics (Arad must be able to open/track tickets), agent-ergonomics (cheap for Architect to read/write), MiFID II audit impact, scale to multi-project + cross-team dependencies, cost.
+
+4. **Recommendation + roadmap:**
+   - Propose ONE option (or a staged adoption path if Option D splits across phases).
+   - Define concrete agent ↔ PM-system integration points: does the Architect open tickets? Does the Director close them when PRs merge? How do failures escalate?
+   - Propose governance-spec amendment if needed (likely a new §13 or a v1.3 amendment covering PM system choice).
+
+5. **SDD implications to address explicitly:**
+   - Planning Layer — does our stack have DAG-of-tasks decomposition today, and who owns it (Director? Architect?)?
+   - Context/Memory Management — how the chosen PM system interacts with MEMORY.md / project memory / per-Architect notepads.
+   - Constraint Enforcement — how the PM system surfaces governance violations.
+   - Self-Healing / Drift Detection — is spec-to-code drift observable in the chosen PM system?
+
+### Non-goals for Topic 3
+
+- Do not provision any PM tooling. Don't create Jira workspaces or GitHub Projects. Recommend; CEO ratifies; then a separate handoff implements.
+
+---
+
+## Topic 5 — Human-Friendly Onboarding Guide Roadmap
+
+*(CEO's numbering skipped 4; preserve "Topic 5" in deliverable filenames to match their document.)*
+
+### What the CEO asked
+
+> Now that we are about to onboard a new dev team, they will need human-friendly guides/manuals to our framework explaining for example our Governance spec (branch protection, review model, CODEOWNERS, MiFID II retention, PR templates, merge strategy, onboarding, etc.), step-by-step explanations for our Ratification mechanism and flow, and any other workflow. Only do this AFTER we've finished preparing the framework and are ready to fully onboard. But this should be planned and inserted into the PR roadmap right now.
+
+### What the deliverable must contain
+
+This is the lightest of the four deliverables — it is a **roadmap**, not the docs themselves.
+
+1. **Inventory of workflows that need human-readable documentation:**
+   - Read the governance spec and list every workflow a new human will encounter in their first 30 days: CODEOWNERS semantics, PR template fields (especially the ratification checklist), commit message conventions, branch naming, squash-merge rules, signed-commits setup (MYTHOS), emergency-direct-merge protocol (mythos-ops), how to open a Decision Record, how to dispute a design call, Discord channel etiquette, agent dispatch conventions, safety-critical path restrictions, CI status-check interpretation, secret-scanning rules.
+   - Cross-reference with the 5 multi-human workflow decisions (Q1–Q5) from the Phase 2 Readiness Report §6.1 — several of those have answers that must land in the onboarding docs.
+
+2. **Proposed doc structure:**
+   - Recommend a location (e.g., `docs/handbook/` or `docs/onboarding/` in the LIMITLESS monorepo; or per-repo `CONTRIBUTING.md` + a central handbook).
+   - Recommend a reading order — what does a new collaborator read on day 1, day 7, day 30.
+   - Recommend tone and length guidelines (these are for humans, not specs — prefer step-by-step + screenshots over formal prose).
+
+3. **Roadmap of PRs (the actual deliverable):**
+   - For each doc, specify: title, target path, rough outline (bullet-level), dependencies on which framework-work-in-progress items must complete first (e.g., "CONTRIBUTING.md for MYTHOS cannot land until Q1–Q5 are answered by CEO"), estimated length.
+   - Order them by readiness: earliest candidates are docs that only reference already-ratified material; later candidates depend on DR-001 Phase 3 landing, branch protection being applied, etc.
+   - Deliver as a checklist the CEO can tick off as PRs land.
+
+4. **Explicit timing statement:**
+   - Confirm the CEO's framing: no onboarding-guide PR merges until the framework is Phase-2 ready. But the roadmap itself lands now so that the docs get written in parallel with the remaining technical-readiness work.
+
+### Non-goals for Topic 5
+
+- Do not write the guides themselves in this PR. This handoff is roadmap-only.
+- Do not duplicate the governance spec. The guides are human translations, not re-specs.
+
+---
+
+## Constraints, process, and reporting
+
+### Constraints
+
+1. **Research + propose only.** Every deliverable is a document. No code, no config changes, no new PRs outside this single deliverable PR.
+2. **Cite evidence.** When making claims about current state, cite the file path and line range. Use `origin/main` via `gh api` — not local working trees (per `feedback_origin_main_over_local_tree.md`).
+3. **Flag unknowns explicitly.** Any claim the Architect cannot verify goes under an "Open Questions" section with a specific owner (CEO / Director / future handoff) and a concrete closing action. Per `feedback_flag_unknowns.md`.
+4. **Match depth to document type.** These are strategic documents the CEO will use to make greenlight decisions — be thorough, don't skim. Per `feedback_depth_matching.md`.
+5. **Integrate with existing framework.** Any proposal must name whether it's a new spec, a governance-spec amendment (v1.3?), a new DR, or a plan. Don't invent a parallel track.
+6. **Cross-reference.** The four topics have overlaps (e.g., Topic 1's benchmark protocol is consumed by Topic 2's Director validation; Topic 3's PM system choice may touch Topic 5's onboarding docs). Call out dependencies explicitly.
+
+### Process
+
+1. Investigate in order: Topic 1 → Topic 2 → Topic 3 → Topic 5 (they have forward dependencies in that order).
+2. Before writing the proposal sections, post a short (≤ 150-word) plan to `#main-ops` confirming scope and any constraint clarifications the Architect needs. Wait for Director/CEO confirmation before drafting the PR.
+3. Produce all four documents in a single branch. Draft PR first (marked "DRAFT" in title) with all four files. Director reviews; iteration happens in PR comments.
+4. When Architect considers the PR ready for CEO ratification, un-draft it. The Director announces in #handoffs.
+
+### Reporting
+
+Post end-of-task report to `#main-ops` with:
+- Branch + PR link
+- One-sentence summary per topic ("Topic 1 = proposed new Agent Configuration Registry under `apps/nanoclaw/agents/manifest.yaml` + quarterly review DR pattern; see spec-XX.md §3")
+- Open Questions list consolidated across all 4 topics
+- Estimated CEO review time (calibration: the Phase 2 Readiness Report was ~690 lines; this deliverable will likely be longer)
+
+### Attribution reminders
+
+Every commit in this PR body ends with:
+
+```
+Authored-by-agent: LIMITLESS main-ops Architect
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+```
+
+PR template ratification checklist must be fully ticked or N/A-marked. No skipped items.
+
+---
+
+## Priority + escalation
+
+**Priority:** high but not urgent. Phase 2 greenlight is pending this work AND the remaining DR-001/DR-002 technical readiness. Both tracks run in parallel — don't rush this at the cost of quality.
+
+**Escalation triggers:**
+- If any topic requires changes to OpenClaw Director config that can't be made safely by the Architect, escalate to Director (me) via #handoffs before proposing.
+- If any topic reveals a gap in a **ratified** governance document (spec v1.2, DR-001, DR-002), do not silently fix it — call it out as an Open Question and propose a DR.
+- If the Architect's research finds that one of the Phase 2 Readiness Report's claims is wrong, call it out explicitly. The readiness report is not canonical — the governance spec is.
+
+---
+
+## Source documents the Architect should start with
+
+| Document | Location | Why it matters |
+|---|---|---|
+| CEO's questions | `docs/superpowers/specs/SDLC phase 2 readiness report questions.md` | The ground truth for this task |
+| Phase 2 readiness report | `docs/superpowers/specs/2026-04-21-agentic-sdlc-phase-2-readiness-report.md` | Context the CEO is responding to |
+| Governance spec v1.2 | `docs/superpowers/specs/2026-04-18-agentic-sdlc-governance.md` | The framework being governed |
+| DR-001 | `docs/decisions/DR-001-agent-identity-and-ratification-flow.md` | Agent identity model |
+| DR-002 | `docs/decisions/DR-002-nanoclaw-source-of-truth-and-deployment.md` | NanoClaw SoT |
+| Division v2 | `docs/superpowers/specs/2026-04-05-division-v2-federated-architecture.md` | Three-tier architecture |
+| GitLab+Jira assessment | PR #54 merged 2026-04-21 | Prior work on Topic 3 |
+| MYTHOS Charter + PRD | `chmod735-dor/mythos` PRs #25, #26, #27 | Context for MYTHOS onboarding path |
+| Per-app Architect CLAUDE.mds | `apps/nanoclaw/groups/discord_{paths,cubes,hub,dt,infra}-eng/CLAUDE.md` | Evidence for Topic 1 |
+
+---
+
+*End of handoff brief. Awaiting CEO approval to dispatch to #main-ops.*

--- a/docs/superpowers/specs/2026-04-21-agentic-sdlc-phase-2-readiness-report.md
+++ b/docs/superpowers/specs/2026-04-21-agentic-sdlc-phase-2-readiness-report.md
@@ -1,0 +1,690 @@
+# Agentic SDLC — Phase 2 Readiness Report
+
+**Date:** 2026-04-21
+**Author:** Director (on CEO request)
+**Classification:** Internal — Strategic
+**Status:** Status report — no ratification required
+**Purpose:** Comprehensive view of the agentic SDLC framework before onboarding the second (MYTHOS) dev team to co-develop with us
+
+---
+
+## Executive Summary
+
+Over the last ~6 weeks we built, deployed and ratified a three-tier federated AI software division and wrote the governance that surrounds it. The framework is now **95% in place** — one engineer handoff (DR-001 Phase 3) remains to close the last audit gap, and the ratification flow has a known interim workaround in the meantime.
+
+**Phase 1 (build the division) is effectively done.** Phase 2 is "let a second human team ship alongside us inside the same framework" — and that is the decision in front of you now.
+
+**Three ratified Decision Records now govern everything we ship:**
+
+| DR | Topic | Merged | Net effect |
+|---|---|---|---|
+| Governance spec v1.0 (PR #55) | Branch protection, review model, CODEOWNERS, MiFID II retention, PR templates, merge strategy, onboarding | 2026-04-18 | **Single operational playbook** for LIMITLESS + MYTHOS + all future repos |
+| DR-001 (PR #60) | Agents are not humans — `[bot]` identity via GitHub Apps | 2026-04-20 | **Closes the self-approval loophole** and gives us cryptographically attributable audit records |
+| DR-002 (PR #62) | Monorepo `apps/nanoclaw/` is the single NanoClaw source of truth; GH Actions → VPS deploy | 2026-04-20 | **Eliminates VPS drift**, makes MYTHOS NanoClaw MiFID II-auditable, gives DR-001 Phase 3 a landing target |
+
+**What's live today:**
+- 3-tier division: CEO → OpenClaw Director (Hetzner) → per-app NanoClaw Architects
+- 5 Architect channels producing autonomous PRs (verified on 2026-04-03 with parallel #23 + #24)
+- Governance + CODEOWNERS + PR templates on **all 3 repos** (LIMITLESS + mythos + mythos-ops)
+- GitHub Apps registered, installed, credentials on both VPS tenants
+- VPS drift audited; 5 class-(a) modifications absorbed into the monorepo (PR #66)
+
+**What's still open:**
+- DR-001 Phase 3 (App-token injection in `container-runner.ts`) — blocked on DR-002 Phase 4
+- DR-002 Phase 2–7 (upstream sync in flight as PR #73, then pipeline + VPS migration)
+- Branch protection not yet applied to any repo (by design — waiting for DR-001 Phase 3)
+- **5 multi-human workflow decisions** blocking `@aradSmith`'s full activation
+
+**Recommendation at the end of this doc:** Do NOT greenlight `@aradSmith` yet. We are one sprint away from being ready — let's close that sprint first so he walks into a stable framework on day 1, not a framework mid-mutation.
+
+---
+
+## 1. Three-Tier Federated Architecture
+
+### 1.1 The tiers
+
+```mermaid
+flowchart TD
+    CEO["🧑 Human CEO (chmod735)<br/>Strategic direction · Ratification · Budget"]
+    DIR["🤖 OpenClaw Director<br/>(Hetzner VPS-1, persistent)<br/>Decomposes goals · Dispatches to Architects<br/>Cron checks · Cross-app coordination · MEMORY.md"]
+
+    subgraph NANOCLAW ["NanoClaw Architects (ephemeral, per-app)"]
+        direction LR
+        PATHS["PATHS<br/>#paths-eng"]
+        CUBES["Cubes+<br/>#cubes-eng"]
+        HUB["HUB<br/>#hub-eng"]
+        DT["Digital Twin<br/>#dt-eng"]
+        INFRA["Infra<br/>#infra-eng"]
+        MYTHOS["MYTHOS<br/>#mythos-eng"]
+    end
+
+    subgraph SUBAGENTS ["Agent SDK subagents (inside each Architect container)"]
+        direction LR
+        EXP["explorer"]
+        PLAN["planner"]
+        EXEC["executor"]
+        VER["verifier"]
+        DBG["debugger"]
+    end
+
+    CEO <-->|"Discord / WhatsApp / Telegram"| DIR
+    DIR -->|"proactive send to app channel"| PATHS
+    DIR -->|"proactive send"| CUBES
+    DIR -->|"proactive send"| HUB
+    DIR -->|"proactive send"| DT
+    DIR -->|"proactive send"| INFRA
+    DIR -->|"proactive send"| MYTHOS
+
+    PATHS -->|"post result"| DIR
+    CUBES -->|"post result"| DIR
+    HUB -->|"post result"| DIR
+    DT -->|"post result"| DIR
+    INFRA -->|"post result"| DIR
+    MYTHOS -->|"post result"| DIR
+
+    PATHS -.-> SUBAGENTS
+    CUBES -.-> SUBAGENTS
+
+    style CEO fill:#ffcccb
+    style DIR fill:#cce5ff
+    style NANOCLAW fill:#e6ffe6
+    style SUBAGENTS fill:#fff4cc
+```
+
+### 1.2 Why three tiers (and not one)
+
+We deliberately split orchestration from execution. v1 (single Architect managing all apps via Agent SDK subagents) worked but was an elaborate remote wrapper around Claude Code — we gained nothing over running Claude Code locally. v2 gets us what we actually wanted: **true parallel execution across apps**, because each Architect is a separate container listening on a separate channel.
+
+| Tier | Concern | Tool |
+|---|---|---|
+| CEO | Direction + ratification | Human-language channels (Discord / WhatsApp / Telegram) |
+| Director | Orchestration, memory, dispatch, cross-app coordination | OpenClaw persistent Gateway + cron + MEMORY.md |
+| Architects | Code investigation + PR creation | NanoClaw containers + Agent SDK subagents |
+
+### 1.3 What runs where
+
+| Component | Host | Process | Persistence |
+|---|---|---|---|
+| OpenClaw Director | Hetzner VPS-1 (204.168.237.211) | systemd user service, native install v2026.4.9 | Persistent (always-on) |
+| NanoClaw host daemon | Hetzner VPS-1 (LIMITLESS) + MYTHOS tenant | systemd service | Persistent |
+| Architect containers | Hetzner VPS-1 | Docker, one per Architect channel | **Ephemeral** (spawned per task) |
+| Monorepo worktrees | `/tmp/nanoclaw-worktrees/discord_{app}-eng/` | Git worktrees, one per task | Ephemeral |
+| CLAUDE.md (per Architect) | `apps/nanoclaw/groups/discord_{app}-eng/CLAUDE.md` | Version-controlled in monorepo | Persistent |
+| Architect state | `/workspace/group/` (mounted per container) | Files | Persistent across Architect invocations |
+
+### 1.4 Verified capability
+
+| Milestone | Date | Evidence |
+|---|---|---|
+| Autonomous investigation (no file paths given) | 2026-04-03 | PR #20 (PATHS lesson basePath) |
+| **Parallel execution across Architects** | 2026-04-03 | PR #23 (Cubes+ health) + PR #24 (DT health+version) created **simultaneously** from different channels |
+| OpenClaw Director bot-to-bot comms | 2026-04-11 | Full Director ↔ Architect ↔ CEO graph verified after `allowBots: true` fix |
+| MYTHOS PRD and roadmap produced autonomously | 2026-04-03/04 | PRs #25, #26, #27 merged; Architect scored 8.5/10 vs Director's 7/10 |
+| End-to-end governance ratification | 2026-04-18/20 | PRs #55, #60, #62 all ratified and squash-merged |
+
+---
+
+## 2. PR #60 — What It Resolved and Why It Matters
+
+PR #60 is the pivot from "we have a working division" to "we have a working *auditable* division." Here is what it did and what it did not do.
+
+### 2.1 The gap it closed
+
+Governance spec v1 §5.1 requires a formal GitHub **Approving Review** for MiFID II ratification. But at the time, every NanoClaw Architect pushed commits using the CEO's personal `GH_TOKEN`. That meant every agent PR was authored by `chmod735`, and GitHub blocks self-approval: `chmod735` cannot formally Approve a PR authored by `chmod735`. The spec's own §5.1 condition #2 was **structurally unreachable**.
+
+PR #60 (DR-001 + spec v1.1 + rollout plan) made the call: agents are not humans — they get their own `[bot]` identity via GitHub Apps. CEO can then formally Approve their PRs, and the audit record becomes a clean three-layer hierarchy.
+
+### 2.2 Identity model before vs after
+
+```mermaid
+flowchart LR
+    subgraph BEFORE ["Before DR-001 — Identity Conflation"]
+        B_CEO[chmod735 human]
+        B_ARCH[Architect container]
+        B_PR["PR author: chmod735"]
+        B_APPROVE["❌ GitHub blocks<br/>self-approval"]
+
+        B_CEO -->|"GH_TOKEN=personal OAuth"| B_ARCH
+        B_ARCH -->|"git push"| B_PR
+        B_CEO -.->|"tries to Approve"| B_APPROVE
+    end
+
+    subgraph AFTER ["After DR-001 Phase 3 — Categorical Separation"]
+        A_CEO[chmod735 human]
+        A_APP["GitHub App<br/>limitless-agent / mythos-agents"]
+        A_ARCH[Architect container]
+        A_PR["PR author:<br/>limitless-agent[bot]"]
+        A_APPROVE["✅ CEO Approves<br/>(author ≠ approver)"]
+
+        A_APP -->|"installation token<br/>1-hour TTL"| A_ARCH
+        A_ARCH -->|"git push + gh pr create"| A_PR
+        A_CEO -->|"Approving Review"| A_APPROVE
+        A_APPROVE --> A_PR
+    end
+
+    style B_APPROVE fill:#ffb3b3
+    style A_APPROVE fill:#b3ffb3
+```
+
+### 2.3 The three-layer attribution hierarchy
+
+Every agent-authored commit now carries three attribution layers:
+
+| Layer | What it records | Where it appears | Example |
+|---|---|---|---|
+| **GitHub author** | Which bot system pushed | Commit history, PR author field, org audit log | `limitless-agent[bot]` |
+| **AI model** | Which model generated the content | Commit message footer trailer | `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` |
+| **Per-agent attribution** (optional LIMITLESS, recommended MYTHOS) | Which Architect authored — distinguishes PATHS vs Cubes+ vs... | Commit body footer | `Authored-by-agent: PATHS Architect` |
+| **Ratifier** | Which human approved + merged | Squash-merge commit author + PR "Approved by" | `chmod735` |
+
+### 2.4 What PR #60 delivered
+
+Three files, 683 lines added:
+
+| File | What |
+|---|---|
+| `docs/decisions/DR-001-agent-identity-and-ratification-flow.md` | Full decision record — 4 options evaluated (single bot / per-agent bots / **GitHub Apps** / signed-commits-only), rationale, consequences, self-correction path |
+| `docs/superpowers/specs/2026-04-18-agentic-sdlc-governance.md` | Spec amended to v1.1 — §5.1 fixed, §8 gains attribution hierarchy, §11.1 AI Architect row shows `[bot]` |
+| `docs/plans/agent-identity-rollout.md` | 7-phase implementation plan with verification checklists, token rotation procedure, recovery procedures for 4 failure modes |
+
+### 2.5 PR #60's post-merge rollout state
+
+| Phase | Status | Done by |
+|---|---|---|
+| 0 — Ratify DR-001 audit record | ✅ Done (rebased onto DR-002's `8b627823`, conflict-resolved, squash-merged as `869f1c95`) | Architect + Director + CEO |
+| 1 — Register + install both Apps | ✅ Done (Mythos app re-registered correctly under `chmod735-dor` after initial misroute) | CEO |
+| 2 — VPS credential staging | ✅ Done (`.pem` keys at `/home/{limitless,mythos}/nanoclaw/keys/*.pem` mode 600; env vars set on both tenants) | Director |
+| 3 — `container-runner.ts` token generation | ⏳ **BLOCKED on DR-002 Phase 4** (VPS migration to monorepo clone); engineer handoff not filed yet | — |
+
+**Interim state:** Agents still push using `chmod735`'s `GH_TOKEN`. The Comment-type review + `RATIFIED` keyword workaround remains in effect. Audit record content is equivalent (same PR, same timestamp, same attribution, grep-able keyword) but it is not the formal §5.1 flow.
+
+### 2.6 Why this matters for onboarding a second team
+
+Once DR-001 Phase 3 lands, every future PR author is **either a human GitHub handle or a `[bot]` identity**. `@aradSmith`'s PRs are clearly human; agent PRs are clearly bot; CEO's own PRs are clearly CEO. An auditor (MiFID II or security) can tell in a glance which category a merge came from. Today, everything looks like `chmod735` authored everything — and that misrepresentation grows worse as we add a second human.
+
+---
+
+## 3. Governance Framework (Spec v1.2)
+
+### 3.1 The spec arc
+
+```mermaid
+gitGraph
+    commit id: "v1.0 (PR #55)"
+    commit id: "Governance baseline"
+    branch dr001
+    commit id: "v1.1 DR-001 (PR #60)"
+    commit id: "Agent identity"
+    checkout main
+    merge dr001
+    branch dr002
+    commit id: "v1.2 DR-002 (PR #62)"
+    commit id: "NanoClaw SoT"
+    checkout main
+    merge dr002
+    commit id: "Framework stable"
+```
+
+| Version | PR | Date | What it added |
+|---|---|---|---|
+| v1.0 | #55 (`5cae9e35`) | 2026-04-18 | 12 sections — branch protection, review model (9-row table), CODEOWNERS, MiFID II ratification, commit conventions, merge strategy, PR templates, versioning, rollout |
+| v1.1 | #60 (`869f1c95`) | 2026-04-20 | DR-001 — §5.1 ratification flow with agent identity decoupled; §8 attribution hierarchy + `Authored-by-agent:` footer; §11.1 shows `[bot]` identity |
+| v1.2 | #62 (`8b627823`) | 2026-04-20 | DR-002 — monorepo as NanoClaw source-of-truth; 3 new open questions (VPS audit, MYTHOS OneCLI port, v2 upgrade timeline) |
+
+Canonical location: `docs/superpowers/specs/2026-04-18-agentic-sdlc-governance.md` on `LIMITLESS-LONGEVITY/limitless` main.
+
+### 3.2 Core principles (from §Executive Summary)
+
+1. **Agents propose; humans ratify.** No agent merges to `main`.
+2. **Every merge is a timestamped, attributable record.** (DR-001 restores the attribution.)
+3. **Safety-critical paths have stricter gates and narrower ownership.**
+4. **The governance model is itself versioned and PR-governed** — this spec evolves by the same rules it imposes.
+
+### 3.3 Review model (the 9-row table)
+
+| Change class | Author | Automated gates | Human approver | Notes |
+|---|---|---|---|---|
+| MYTHOS — Safety-critical (`engine/gates/`, `engine/ibkr/`, `db/migrations/`) | Architect/Engineer | Build + tests + `gate-invariant-check` | **CEO + Safety Reviewer** (Phase 3+) | DR required for every non-trivial choice |
+| MYTHOS — Planning deliverables (Charter, SOW, SRS, FRS, DDS, SDD) | MYTHOS Architect | Ratification checklist in PR body | CEO (checklist ticked + "RATIFIED") | MiFID II audit record |
+| MYTHOS — Decision Records | MYTHOS Architect | None | CEO | DR-NNN files; lightweight |
+| MYTHOS — Implementation (non-safety) | Architect/Engineer | Build + tests | CEO | `sidecar/`, `docs/`, non-gate code |
+| MYTHOS — Infrastructure | MYTHOS Architect | Docker build smoke | CEO | Schema migrations require DR |
+| LIMITLESS — App code | Per-app Architect | `pnpm build` + tests | CEO | Normal dev cycle |
+| LIMITLESS — Infra | Infra Architect | `terraform plan` in PR body | CEO | Plan output required |
+| NanoClaw — Tier 3 behavioral | Architect | Build + vitest | CEO | Follows self-mod governance |
+| Governance/spec docs | Architect | None | CEO | This document is an example |
+
+Agent-to-agent review is **advisory only**. It does not substitute for CEO approval on any path.
+
+### 3.4 Branch protection (policy written, not yet applied)
+
+Branch protection is deliberately **not yet applied** to any of the 3 repos. The spec defines it strictly (§1.2) but we intentionally deferred rollout Step 1.3 until DR-001 Phase 3 ships. Why: the moment we apply "require 1 approving review" with the current CEO-token identity model, every agent PR becomes structurally unmergeable.
+
+| Setting | Universal baseline | MYTHOS addition |
+|---|---|---|
+| Require PR before merging | ✅ | ✅ |
+| Required approving reviews | 1 (CEO) | 1 (CEO) → CEO + Safety Reviewer (Phase 3+) |
+| Dismiss stale reviews on new commits | ✅ | ✅ |
+| Require review from Code Owners | ✅ | ✅ |
+| Require branches up to date | ✅ | ✅ |
+| Require conversation resolution | ✅ | ✅ |
+| Restrict who can push | CEO admins only | CEO admins only |
+| Allow force pushes / deletions | ❌ | ❌ |
+| **Require signed commits** | — | ✅ **MYTHOS only** (MiFID II) |
+| **Require linear history** | — | ✅ **MYTHOS only** (clean audit chain) |
+
+### 3.5 Ratification mechanism (MiFID II Art. 25 compliant)
+
+A merge is ratified when ALL are true:
+
+1. All PR-body ratification checkboxes ticked
+2. CEO submits a GitHub **Approving Review** (not a Comment)
+3. Review body contains `RATIFIED` or `Approved`
+4. All required status checks pass
+5. No unresolved review conversations
+
+**Retention:** GitHub native retention indefinitely + weekly/daily `gh api` export to operator-controlled WORM storage (Backblaze B2 / S3 Object Lock). MiFIR Art. 25(1) mandates 5 years; Ireland CBI extends to 7; our design target is 7.
+
+### 3.6 The ratification flow, visualised
+
+```mermaid
+sequenceDiagram
+    actor CEO
+    participant DIR as Director
+    participant ARCH as Architect
+    participant GH as GitHub
+    participant CI as CI checks
+
+    CEO->>DIR: "Ship Garmin integration"
+    DIR->>DIR: Decompose → app-level task
+    DIR->>ARCH: Discord proactive send to #app-eng
+    ARCH->>ARCH: Investigate + plan + execute (Agent SDK)
+    ARCH->>GH: git push → gh pr create (PR template applied)
+    GH->>CI: Required status checks run
+    CI-->>GH: ✅ build / test / typecheck pass
+    ARCH->>DIR: "Done. PR #N. Changes files X,Y,Z"
+    DIR->>CEO: "PR #N ready for review"
+    CEO->>GH: Read diff, tick ratification checkboxes
+    alt DR-001 Phase 3 live
+        CEO->>GH: Submit Approving Review with "RATIFIED"
+    else Interim (current state)
+        CEO->>GH: Submit Comment-review with "RATIFIED"
+    end
+    CEO->>GH: Squash + merge
+    GH->>GH: Auto-delete head branch
+    GH-->>DIR: Merge event (optional webhook)
+    DIR->>CEO: "Merged. Commit <sha>."
+
+    Note over CEO,GH: MiFID II audit record preserved:<br/>PR body + review + squash commit
+```
+
+### 3.7 Commit message contract
+
+```
+type(scope): subject line ≤72 chars
+
+Body: what and why (not how). Wrap at 72 chars.
+Multiple paragraphs allowed.
+
+Footer:
+Authored-by-agent: PATHS Architect          ← required for MYTHOS, recommended for LIMITLESS
+ROADMAP-REF: P1-INFRA-001                   ← when linking to a ROADMAP ticket
+Reviewed-by: CEO
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+```
+
+**Merge strategy:** squash-merge + delete branch, always. Merge commits and rebase-merges are disabled. One commit per PR = one ratification decision = one atomic audit record.
+
+### 3.8 Rollout state across repos (CODEOWNERS + PR templates)
+
+| Repo | Rollout PR | Status | Merge commit |
+|---|---|---|---|
+| `chmod735-dor/mythos` | #2 | ✅ Merged 2026-04-19 | First-ever merge under new governance |
+| `chmod735-dor/mythos-ops` | #1 | ✅ Merged 2026-04-20 | `94a73893` |
+| `LIMITLESS-LONGEVITY/limitless` | #59 | ✅ Merged 2026-04-20 | `96262ff8` |
+
+All 3 repos now have CODEOWNERS + `pull_request_template.md`. Branch protection application (§12.1 Steps 1.3–1.6) is deferred pending DR-001 Phase 3 + multi-human workflow decisions.
+
+---
+
+## 4. DR-002 — NanoClaw Source of Truth and Deploy Pipeline
+
+### 4.1 Problem it solved
+
+Three copies of NanoClaw existed, drifting independently:
+
+```mermaid
+flowchart LR
+    UP["🌐 qwibitai/nanoclaw upstream<br/>v1.2.53"]
+    FORK["LIMITLESS-LONGEVITY/nanoclaw fork<br/>v1.2.46<br/>16 days, 7 versions behind<br/>⚠️ ZERO LIMITLESS-specific commits"]
+    MONO["apps/nanoclaw/ in monorepo<br/>v1.2.46<br/>ALL LIMITLESS customization lives HERE<br/>(discord.ts, MONOREPO_PATH, worktrees...)"]
+    VPS_L["/home/limitless/nanoclaw<br/>Running service (LIMITLESS)<br/>10+ uncommitted local mods"]
+    VPS_M["/home/mythos/nanoclaw<br/>Running service (MYTHOS)<br/>❌ NOT A GIT REPO<br/>rsync copy, unknown state"]
+
+    UP -.-> FORK
+    FORK -.->|"never propagates"| MONO
+    MONO -.->|"manual SSH patching — failed once (PR #53)"| VPS_L
+    VPS_L -->|"rsync (one-time)"| VPS_M
+
+    style VPS_M fill:#ffb3b3
+    style FORK fill:#ffe6b3
+```
+
+The manual-propagation pattern (merge monorepo → Director SSH-patches VPS) failed once already on PR #53. MYTHOS's deployed tree isn't even a git repo — **it has no audit trail**, which is incompatible with MiFID II.
+
+### 4.2 DR-002 decision
+
+**Option B chosen**: `apps/nanoclaw/` in the monorepo is authoritative. GitHub Actions SSH-deploys to both VPS tenants on merge to `main`. Fork is retained only as an upstream-staging buffer.
+
+```mermaid
+flowchart LR
+    UP["🌐 qwibitai/nanoclaw"]
+    FORK["LIMITLESS-LONGEVITY/nanoclaw<br/>🏷️ Upstream staging buffer only"]
+    MONO["📦 apps/nanoclaw/ in monorepo<br/><b>AUTHORITATIVE</b>"]
+    GHA["⚙️ GitHub Actions<br/>deploy-nanoclaw.yml<br/>path filter: apps/nanoclaw/**"]
+    VPS_L["🖥️ /home/limitless/nanoclaw<br/>sparse clone of monorepo"]
+    VPS_M["🖥️ /home/mythos/nanoclaw<br/>sparse clone of monorepo<br/>✅ git-tracked = MiFID II auditable"]
+
+    UP -->|"weekly cherry-pick"| FORK
+    FORK -->|"PR into monorepo"| MONO
+    MONO -->|"squash-merge to main"| GHA
+    GHA -->|"SSH deploy<br/>appleboy/ssh-action"| VPS_L
+    GHA -->|"SSH deploy"| VPS_M
+
+    style MONO fill:#b3ffb3
+    style VPS_M fill:#b3ffb3
+```
+
+### 4.3 Why this was the gating decision for DR-001 Phase 3
+
+DR-001 Phase 3 needs to land in `container-runner.ts` and be deployed to both VPS tenants. Before DR-002, "which tree gets the change and how does it reach the VPS" had no answer. DR-002 gave it one: **land the PR in `apps/nanoclaw/` in the monorepo, and the pipeline deploys it.**
+
+Hence DR-001 Phase 3 is sequenced *after* DR-002 Phase 4 (VPS migration to monorepo clone).
+
+### 4.4 DR-002 rollout state
+
+| Phase | What | Status |
+|---|---|---|
+| 1 — VPS drift audit | Classify the 10 "modified" files | ✅ Done (2026-04-20). 7 byte-identical to origin/main; 3 absorbed + 2 new files |
+| 1.3 — Absorb Class (a) items | Pull real local mods into monorepo | ✅ Done (PR #66 `50ca8031`). Added `container/entrypoint.sh`, `discord.test.ts` (777-line vitest suite), Dockerfile pnpm+COPY pattern, container-runner `.git` passthrough |
+| 2 — Monorepo upstream sync | 1.2.46 → 1.2.53 | ⏳ **PR #73 open** (filed 2026-04-21 — CI passing, awaiting ratification). Adds `ONECLI_API_KEY`, `session-cleanup.ts`, version bump |
+| 3 — GitHub Actions deploy pipeline | `appleboy/ssh-action` + command-restricted deploy key | Pending |
+| 4 — VPS clone migration | LIMITLESS multi-remote clone → monorepo sparse clone; MYTHOS rsync → git clone | Pending (unlocks DR-001 Phase 3) |
+| 5 — MYTHOS OneCLI provisioning | Own instance on different port (LIMITLESS = 10254) | Pending |
+| 6 — DR-001 Phase 3 implementation | `container-runner.ts` mints App installation token at spawn | Pending — engineer handoff filed only after Phases 3+4 done |
+| 7 — Ongoing upstream sync protocol | Weekly check + collision table | Documented |
+
+### 4.5 Where we are on DR-002 rollout (as of 2026-04-21)
+
+```mermaid
+gantt
+    title DR-002 Rollout
+    dateFormat YYYY-MM-DD
+    axisFormat %m-%d
+
+    section Phase 1
+    VPS drift audit                 :done, p1a, 2026-04-20, 1d
+    Absorb Class (a) items (PR #66) :done, p1b, 2026-04-20, 1d
+
+    section Phase 2
+    Upstream sync PR #73 (open)     :active, p2, 2026-04-21, 2d
+
+    section Phase 3
+    GH Actions deploy pipeline      :p3, after p2, 3d
+
+    section Phase 4
+    LIMITLESS VPS migration         :p4a, after p3, 1d
+    MYTHOS VPS migration            :p4b, after p4a, 1d
+
+    section Phase 5
+    MYTHOS OneCLI                   :p5, after p4b, 2d
+
+    section Phase 6
+    DR-001 Phase 3 (engineer PR)    :crit, p6, after p4b, 3d
+```
+
+Realistic end-to-end: **~1.5 sprints** to reach fully-automated deploy + bot-identity PRs.
+
+---
+
+## 5. Current State Matrix
+
+One table per concern, so you can scan.
+
+### 5.1 Division v2 infrastructure
+
+| Component | State | Notes |
+|---|---|---|
+| OpenClaw Director on Hetzner VPS-1 | ✅ Live | Native install v2026.4.9, Node 24.14.1 via fnm, systemd user service |
+| Per-app Architect CLAUDE.md | ✅ 5 live (PATHS, Cubes+, HUB, DT, Infra) | `apps/nanoclaw/groups/discord_{app}-eng/CLAUDE.md` |
+| MYTHOS Architect | ✅ Running in `chmod735-dor/mythos` separately | CLAUDE.md live; produced PRD + roadmap autonomously |
+| Parallel execution verified | ✅ Yes | PR #23 + #24 concurrent creation (2026-04-03) |
+| Director ↔ Architect ↔ CEO comms | ✅ All three edges verified | `allowBots: true` fix was the final unlock (2026-04-11) |
+| Multi-channel CEO interface | ✅ Discord confirmed | WhatsApp + Telegram supported by OpenClaw but currently unused |
+| Cross-app coordination | ⏳ Manual | Phase 4 feature — OpenClaw detects API-contract changes from PR diffs (deferred) |
+| Fleet automation (Terraform + Ansible) | ⏳ Foundation in place | `infra-code` repo has module + 6 roles; full auto-scale deferred |
+
+### 5.2 Governance + identity
+
+| Concern | State | Blocker |
+|---|---|---|
+| Governance spec v1.2 | ✅ Ratified, on main (LIMITLESS) | — |
+| DR-001 audit record | ✅ Ratified (PR #60) | — |
+| DR-002 audit record | ✅ Ratified (PR #62) | — |
+| GitHub Apps registered | ✅ `limitless-agent` + `mythos-agents` | — |
+| GitHub Apps installed | ✅ All 3 repos | — |
+| VPS credential staging (both tenants) | ✅ Done | — |
+| Bot-identity PR authorship (DR-001 Phase 3) | ❌ Not live | Blocked on DR-002 Phase 4 |
+| Formal Approving Review flow | ⏳ Interim (Comment-review + `RATIFIED`) | Unlocks with Phase 3 |
+| Branch protection applied | ❌ Not yet | Deliberately deferred until Phase 3 |
+| CODEOWNERS + PR template | ✅ All 3 repos | — |
+
+### 5.3 NanoClaw source of truth
+
+| Concern | State |
+|---|---|
+| VPS drift audit complete | ✅ Phase 1 done |
+| Class (a) items absorbed | ✅ PR #66 merged |
+| Upstream sync to 1.2.53 | ⏳ PR #73 open (CI green) |
+| GH Actions deploy pipeline | ❌ Pending (Phase 3) |
+| LIMITLESS VPS = monorepo clone | ❌ Still multi-remote clone |
+| MYTHOS VPS = git clone | ❌ Still rsync copy (MiFID II gap) |
+| MYTHOS OneCLI provisioned | ❌ Pending |
+| Upstream sync protocol documented | ✅ In rollout plan |
+
+### 5.4 MYTHOS-specific
+
+| Concern | State |
+|---|---|
+| MYTHOS repo (`chmod735-dor/mythos`) live | ✅ |
+| MYTHOS-ops repo (`chmod735-dor/mythos-ops`) live | ✅ |
+| Product Brief + PRD merged | ✅ PRs #25 (Charter), #26, #27 |
+| Phase 1 roadmap + Kanban | ✅ PR #27 |
+| MYTHOS Architect identity CLAUDE.md | ✅ PR #50 |
+| GitLab + Jira adoption impact assessment | ✅ PR #54 |
+
+### 5.5 Collaborator onboarding (`@aradSmith` / `aradsky`)
+
+| Step | Status |
+|---|---|
+| 1 — GitHub admin on both mythos repos | ✅ Added |
+| 2 — CODEOWNERS PR (mythos #3) | ⏳ Open, awaiting ratification |
+| 2 — CODEOWNERS PR (mythos-ops #2) | ⏳ Open, awaiting ratification |
+| 3 — Discord D.O.R OPS guild membership | ✅ Joined |
+| 3 — Full channel grants (`#main-ops`, `#mythos-eng`, `#handoffs`, `#humans`) | ❌ Currently `#general` only |
+| 4 — Multi-human workflow decisions | ❌ **Blocking full activation** |
+| 5 — CONTRIBUTING.md for MYTHOS | ❌ Pending Step 4 |
+| 6 — First task / first PR | ❌ Pending Steps 3–5 |
+
+---
+
+## 6. Onboarding Readiness for @aradSmith
+
+### 6.1 The five decisions blocking full activation
+
+These are not engineering questions — they are operator decisions that nobody can answer without you. The framework is ready for a second human, but these call-outs are missing:
+
+```mermaid
+flowchart TD
+    START["@aradSmith has admin on<br/>both mythos repos + Discord #general"]
+
+    D1["Q1 Signed-commits capability<br/>Does Arad have GPG/SSH commit signing?<br/>Spec §1.2 requires it on MYTHOS"]
+    D2["Q2 Review/merge flow with 2 humans<br/>• Arad → Write (not Admin)?<br/>• Both as CODEOWNERS → require both, or one?<br/>• Formal Approving Review now that author ≠ approver?"]
+    D3["Q3 Architectural-dispute resolution<br/>§11.1 says escalate to CEO.<br/>Via Discord #handoffs? Decision Record?"]
+    D4["Q4 Safety-critical path gate<br/>engine/gates/, engine/ibkr/, db/migrations/<br/>are CEO-only. What if Arad touches adjacent code?<br/>Joint review? Doc contract?"]
+    D5["Q5 Emergency-direct-merge exception<br/>§1.2 mythos-ops 24h ops patch authority.<br/>Arad gets this, or CEO-only?"]
+
+    READY["Full activation:<br/>• Merge CODEOWNERS PRs<br/>• Complete channel grants<br/>• CONTRIBUTING.md<br/>• First task handoff"]
+
+    START --> D1
+    D1 --> D2
+    D2 --> D3
+    D3 --> D4
+    D4 --> D5
+    D5 --> READY
+
+    style D1 fill:#ffe6b3
+    style D2 fill:#ffe6b3
+    style D3 fill:#ffe6b3
+    style D4 fill:#ffe6b3
+    style D5 fill:#ffe6b3
+    style READY fill:#b3ffb3
+```
+
+### 6.2 Recommended answers (my read — you decide)
+
+| # | Question | Suggestion | Rationale |
+|---|---|---|---|
+| Q1 | Signed commits | Require before activation. Have Arad configure GPG or SSH commit signing as part of CONTRIBUTING.md. | MYTHOS is MiFID II-regulated. Cryptographic authorship is part of the audit story. Cheap to set up once, impossible to retrofit cleanly. |
+| Q2a | Arad's permission level | Move from Admin → **Write** once CODEOWNERS PRs merge | Spec §11.1 — "Collaborating team lead — cannot merge". Admin is fine for bootstrap, Write is the steady state. |
+| Q2b | CODEOWNERS joint-reviewer semantics | **One-of-both suffices** on most paths; **both-required** on safety-critical (when both are in CODEOWNERS there). | GitHub's CODEOWNERS doesn't natively distinguish these — we encode it via the "Required approving reviews" count in branch protection (1 = any owner; 2 = both if both are owners). |
+| Q2c | Formal Approving Review for Arad's PRs | **Yes — works today.** Arad's author ≠ CEO's approver; GitHub's self-approval block doesn't apply. Human-to-human is the clean case. | This is why DR-001 matters: the self-approval block only affected agent PRs. Human-to-human has always worked. |
+| Q3 | Architectural disputes | **Decision Record in `docs/decisions/DR-NNN-...`** authored by whichever side opens the dispute, ratified by CEO. Discussion surface = PR comments on the DR PR, not freeform Discord. | Keeps the audit chain intact. MiFID II friendly. Matches how DR-001/DR-002 themselves worked. |
+| Q4 | Safety-critical adjacency | Explicit doc contract in `engine/gates/README.md` listing upstream inputs + invariants. Any PR changing those inputs must explicitly cite the contract in its body. | Less process than joint-review on every adjacent PR; more enforceable than "be careful". |
+| Q5 | Emergency-direct-merge on mythos-ops | **CEO-only.** Arad can open the follow-up PR, but the direct-merge bit requires operator accountability. | Keeps the last-resort lever single-operator. Spec §1.2 already contemplates this. |
+
+### 6.3 What's already safe for Arad to do TODAY (even without Q1–Q5 resolved)
+
+- Read all 3 repos on GitHub
+- Read `#general` on Discord
+- Clone MYTHOS repos locally
+- Draft PRs against MYTHOS (branch protection isn't enforced yet; CODEOWNERS PRs #2/#3 aren't merged; but nothing blocks *drafting*)
+- Author Decision Records under `docs/decisions/` for review
+
+What's NOT safe yet:
+- Merging anything (only CEO merges)
+- Accessing operational secrets in mythos-ops
+- Touching safety-critical paths without joint-review decision (Q4)
+- Authorizing credential or CI-key changes
+
+---
+
+## 7. Phase 2 Readiness — The One-Page Verdict
+
+### 7.1 Green-lights (we're ready)
+
+- ✅ Governance spec is ratified on all 3 repos
+- ✅ CODEOWNERS + PR templates on all 3 repos
+- ✅ MYTHOS has its own Architect + Charter + PRD + Phase 1 roadmap
+- ✅ DR-001 + DR-002 decisions both ratified
+- ✅ GitHub Apps provisioned; `@aradSmith` has admin + Discord membership
+- ✅ Branch protection policy is designed (just not yet applied)
+- ✅ The framework demonstrably produces autonomous ratified PRs at scale (#23, #24, #26, #27, #50, #52, #53, #54, #55, #59, #60, #62, #66)
+
+### 7.2 Yellow-lights (working, but incomplete)
+
+- ⚠️ DR-001 Phase 3 is behind DR-002 Phase 4 — interim workaround (Comment-review + `RATIFIED`) is running
+- ⚠️ PR #73 (upstream sync to 1.2.53) is open, not yet merged
+- ⚠️ Branch protection not yet applied (by design)
+- ⚠️ No GH Actions deploy pipeline yet — NanoClaw changes still need manual/Director propagation
+
+### 7.3 Red-lights (real blockers for Arad)
+
+- ❌ **5 multi-human workflow decisions** (§6.1) not made — he literally doesn't know how to raise a dispute, whether he can merge emergency ops patches, how safety-critical adjacency is reviewed
+- ❌ **CONTRIBUTING.md not written** — no single document that explains to a new human "this is how we ship here"
+- ❌ **Discord channel grants incomplete** — he can't even see `#mythos-eng` yet, which is where work gets dispatched
+- ❌ **MYTHOS VPS is not yet MiFID II-compliant** (rsync copy, not git-tracked) — any MYTHOS code Arad writes today deploys via a trail we can't reconstruct
+
+### 7.4 My recommendation
+
+**Do not greenlight co-development yet.** We are ~1 sprint from a clean handover. Specifically:
+
+```mermaid
+flowchart LR
+    T1["1. Merge PR #73<br/>(upstream sync)"]
+    T2["2. DR-002 Phase 3+4<br/>(GH Actions + VPS migration)"]
+    T3["3. DR-001 Phase 3<br/>(engineer handoff)"]
+    T4["4. Apply branch protection<br/>(§12.1 Steps 1.3–1.6)"]
+
+    Q["5. Answer Q1–Q5<br/>(you decide)"]
+    COW["6. Merge CODEOWNERS PRs<br/>(mythos#3, mythos-ops#2)"]
+    CHAN["7. Grant Arad full channels"]
+    CONTRIB["8. Write CONTRIBUTING.md<br/>(references answers to Q1–Q5)"]
+    TASK["9. First task handoff"]
+
+    T1 --> T2 --> T3 --> T4 --> GREEN
+
+    Q --> COW --> CHAN --> CONTRIB --> GREEN
+
+    GREEN["🟢 Full greenlight"] --> TASK
+
+    style T1 fill:#fff4cc
+    style T2 fill:#fff4cc
+    style T3 fill:#fff4cc
+    style T4 fill:#fff4cc
+    style GREEN fill:#b3ffb3
+```
+
+The top track is **technical readiness** (framework closes its final audit gap).
+The bottom track is **operational readiness** (Arad has a written contract for how he participates).
+
+Both can run in parallel. Bottom track is cheaper and faster — if you want to, we can close Q1–Q5 + CONTRIBUTING.md this week while DR-001/DR-002 finish in the background, and greenlight Arad the moment the technical track lands.
+
+---
+
+## 8. Open Questions Still on the Spec
+
+These are separately tracked in the spec itself (`§Open Questions`) — listed here for your awareness:
+
+| # | Question | Owner | Timing |
+|---|---|---|---|
+| OQ1 | Formal DPA with GitHub for MiFID II record-keeping | Legal review | Before Phase 4 live trading |
+| OQ2 | Safety Reviewer designation (external quantitative/regulatory expert) | CEO | By Phase 3 kick-off |
+| OQ3 | **RESOLVED** — signed-commits tooling (GitHub auto-signs squash merges) | — | — |
+| OQ4 | PR #1 on `chmod735-dor/mythos` — apply grandfather clause | Ops | Before branch protection activates |
+| OQ5 | DR-001 Phase 3 implementation PR | Engineer handoff | After DR-002 Phase 4 |
+| OQ6 | MYTHOS OneCLI provisioning | Operator | DR-002 Phase 5 |
+| OQ7 | **CONFIRMED** — Agent Vault ≠ DR-001 Phase 3 (complementary) | — | — |
+| OQ8 | Upstream NanoClaw v2 upgrade timeline | CEO | When v2 stabilizes (est. 4–8 weeks) |
+
+---
+
+## 9. References
+
+| Document | Location |
+|---|---|
+| Governance spec v1.2 | `docs/superpowers/specs/2026-04-18-agentic-sdlc-governance.md` |
+| DR-001 | `docs/decisions/DR-001-agent-identity-and-ratification-flow.md` |
+| DR-001 rollout plan | `docs/plans/agent-identity-rollout.md` |
+| DR-002 | `docs/decisions/DR-002-nanoclaw-source-of-truth-and-deployment.md` |
+| DR-002 rollout plan | `docs/plans/nanoclaw-source-of-truth-rollout.md` |
+| Division v2 architecture | `docs/superpowers/specs/2026-04-05-division-v2-federated-architecture.md` |
+| VPS audit report (Phase 1) | `docs/plans/vps-audit-2026-04-20/REPORT.md` |
+| Phase 1 monorepo migration | `docs/superpowers/plans/2026-04-03-directory-cleanup-migration-plan.md` (complete) |
+
+| PR | Topic | Merge commit |
+|---|---|---|
+| #55 | Governance v1.0 | `5cae9e35` |
+| #59 | LIMITLESS CODEOWNERS + PR template | `96262ff8` |
+| #60 | DR-001 + spec v1.1 + rollout plan | `869f1c95` |
+| #62 | DR-002 + spec v1.2 + rollout plan | `8b627823` |
+| #66 | VPS audit absorb (DR-002 Phase 1.3) | `50ca8031` |
+| #73 | Upstream sync 1.2.46 → 1.2.53 (DR-002 Phase 2) | open, CI green |
+| mythos #2 | Governance rollout | merged 2026-04-19 |
+| mythos #3 | `@aradSmith` joint-reviewer CODEOWNERS | open |
+| mythos-ops #1 | Governance rollout | `94a73893` |
+| mythos-ops #2 | `@aradSmith` joint-reviewer CODEOWNERS | open |
+
+---
+
+*End of report. For follow-ups, propose a Decision Record under `docs/decisions/` and file a PR — the framework will handle the rest.*

--- a/docs/superpowers/specs/SDLC phase 2 readiness report questions.md
+++ b/docs/superpowers/specs/SDLC phase 2 readiness report questions.md
@@ -1,0 +1,94 @@
+# 1 Structured Approach to Coding Agents' Setup and Config
+- Limitless/Mythos Research Process to determine the optimal Agents' Setup and Configuration: how were the different settings for the architects arrived at? i.e. what was the process that resulted in our method of setting up an agent like the architect? what have we based our different md files for each agent on? was it specific to anthropic models? was it model agnostic? did we put in comparison metrics to figure out what works best? etc. Did we make sure this process is ongoing since agents' setup and config is an evloving process that is also tied to new model releases (as well as changes made to coding harnesses and other relevant tech). Did we codify this process so it too is versioned and auditable and is constant updated and evolved?
+- A structured and Controlled setup and config file list - do we have an system to track all the files determinig the settings of each agent (e.g. architect, workers sub agents, etc)?
+- Documentation: which files in our documentation ducomente all the above topics
+# 2 OpenClaw Director
+- The director is currently not integrated into our workflow. While we have set it up in practice the current workflow is Human CEO to NanoClaw architect. This has been the result of our pre governances spec workflow which was not well structrued and the fact that we have since addressed these issues piecemeal so we haven't yet started working according to our new spec. Before we start using the Director as per our new specs we need to make sure it is indeed up to the task. While the nanoclaw Architect has a proven track record and we have tested its performance several times by reviewing and comparing its work on given tasks with the Claude Code instance running in our local dev machine using Opus 4.6 and 4.7, the same was not done for the director. Before we integrate it to our workflow we must answer all the above questions regarding our NanoClaw Architect apllied to our OpenClaw Director. We must also stress test it and make the same review for its performance as we did for the NanoClaw Architect.
+# 3 Jira integration vs. Alternative project management system
+- Currently Agile is the most popular methodology/framework used in software development for the SDLC. Human led teams use Jira (or similair proudct like Linear) for software project managment. While this fits humans we have already seen the introduction of agentic AI is now changing the SDLC. Spec-Driven Development is leading the way for agentic oriented SDLC and is being described as "The Waterfall Strikes Back"—but with a fundamental architectural twist that prevents it from suffering Waterfall’s historical failures.
+
+The key distinction is that while Waterfall uses specifications as static documentation, Agentic SDD treats them as executable artifacts and "version control for your thinking." In this model:
+
+- The Spec is the Code: The "Agentic Operating System" you are building serves as the runtime that materializes the specification into reality.
+
+- Velocity Negates Rigidity: Because an agent can implement a 50-page spec in minutes rather than months, the "cost of being wrong" (Waterfall's biggest flaw) drops to near zero.
+
+- Recursive Iteration: You aren't just doing "Big Design Up Front"; you are doing "Continuous Design" where the spec is the primary surface of iteration, not the source code.
+
+This transition represents a move from "Vibe Coding" (ad-hoc prompting) to "Architectural Determinism," where the developer's role shifts from a line-by-line implementer to a high-level system orchestrator.
+
+What we now need to figure out is how our new agentic ai oriented SDLC integrates the components of the pre agentic ai SDLC into it. Are we using Jira and if so how? Are the humans directing the agents in our framework (e.g. the Director and the Architect) opening Jira tickets for them and are the agents using Jira themselves to go through the development workflow for the tickts?
+
+If we are not using Jira what are we using intead? Is the human only using discord (to direct a task at an agent) and github (to review and merge PRs) to replace the whole Jira workflow? Will this be enough in complicated development project (highly unlikely)? and other similair questions.
+
+Following is a brief report about this topic:
+
+## 1. Executive Summary
+The shift toward **Agentic Coding** and **Spec-Driven Development (SDD)** has sparked a debate within the engineering community. Traditional Agile enthusiasts argue that SDD's reliance on upfront specifications is a regressive move toward the **Waterfall** model. However, research into the "Agentic SDLC" suggests that SDD is not a return to Waterfall, but a **compression** of it. By leveraging AI agents to reduce the "Implementation" phase from weeks to minutes, the methodology combines the **structural rigor** of Waterfall with the **iterative speed** of Agile.
+
+---
+
+## 2. Comparative Analysis: The SDLC Evolution
+
+| Feature | Traditional Waterfall | Modern Agile | Agentic Spec-Driven (SDD) |
+| :--- | :--- | :--- | :--- |
+| **Primary Artifact** | Comprehensive Documentation | Working Software | **Machine-Readable Spec** |
+| **Iteration Cycle** | Months / Years | 2 - 4 Weeks (Sprints) | **Minutes / Hours (Agentic Loops)** |
+| **Role of Developer** | Implementer | Collaborator | **Architect / Orchestrator** |
+| **Change Cost** | Extremely High | Moderate | **Near-Zero (Regeneration)** |
+| **Reliability** | High (if spec is perfect) | Variable (Speed over depth) | **High (Deterministic & Verifiable)** |
+
+---
+
+## 3. Why It Feels Like "Upgraded Waterfall"
+The perception that SDD is "Waterfall 2.0" is accurate in several structural ways:
+1.  **Primacy of Design:** Like Waterfall, SDD demands that you think before you build. You cannot simply "vibe code" with complex agents; you must define the "what" before the agent can handle the "how."
+2.  **Top-Down Decomposition:** The workflow typically follows a linear decomposition: `Product Requirements -> Technical Spec -> Task List -> Code`. 
+3.  **The "Big Design Up Front" (BDUF) Return:** For an agent to maintain system-wide context, it requires a high-level architectural map, a hallmark of traditional engineering that Agile sought to minimize.
+
+---
+
+## 4. The "Agentic OS" Paradox: Why It's Not Waterfall
+While the *structure* is linear, the *dynamics* are entirely new. The "Agentic Operating System" you are building changes the physics of development:
+
+### A. The Velocity of Implementation
+In Waterfall, the "Implementation" phase was a massive wall. In an Agentic SDLC, the implementation is a **runtime execution**. If the spec is wrong, you don't "re-code" for three months; you update the spec and the Agentic OS "re-materializes" the system in minutes.
+
+### B. "Version Control for Your Thinking"
+Modern SDD (using tools like GitHub Spec Kit) treats specifications as **living artifacts**. They are checked into Git, versioned, and branched. This makes the spec the "Single Source of Truth" (SSOT) that is continuously validated against the output.
+
+### C. The Recursive Feedback Loop
+Unlike Waterfall, which is a one-way street, the Agentic SDLC is a **recursive loop**.
+* **Spec -> Agent -> Result -> Validation -> (Refine Spec) -> Repeat.**
+This makes the methodology **Hyper-Agile** at the architectural level.
+
+---
+
+## 5. Architectural Requirements for an Agentic OS
+To successfully move from Agile to an Agentic SDLC, your "Agentic Operating System" must provide the following "Kernel" services:
+
+1.  **Planning Layer:** Decomposing high-level intent into a directed acyclic graph (DAG) of tasks.
+2.  **Context/Memory Management:** Ensuring agents don't "forget" the spec when working on a specific file (solving the long-context window problem).
+3.  **Constraint Enforcement:** A governance layer that ensures agent-generated code never violates the "Living Spec."
+4.  **Self-Healing/Drift Detection:** Automatically identifying when the code has diverged from the specification and triggering an agentic "repair" cycle.
+
+---
+
+## 6. Final Verdict: The "Compressed Waterfall"
+Spec-Driven Development is an **Upgraded Waterfall**, but "Waterfall" is no longer a pejorative. 
+
+Agile was a workaround for the **slowness and fallibility of human implementation**. When implementation becomes a commodity provided by agents, the bottleneck shifts back to **Intent and Architecture**. 
+
+We are entering the era of **"Architectural Agile,"** where we iterate on designs with the same frequency we used to iterate on code. Your journey to redesign Agile for agents is actually a journey toward **Executable Architecture**.
+
+---
+## References & Resources
+* *Spec-Driven Development: The Waterfall Strikes Back* (Marmelab, 2025)
+* *Agentic SDLC: From Handcrafted to Autonomous* (PwC Research, 2026)
+* *GitHub Spec Kit & The Kiro IDE Paradigm* (VentureBeat, 2026)
+* *Search Query: "Agentic Operating System architecture for SDD"*
+
+
+# 5 Human Friendly Guides / Manuals
+  different parts of our documentation detailing workflows and actions which involve humans. For example, now that we are about to onboard a new dev team, they will need a human friendly guides / manuals to our framework explaining for example our Governance spec (branch protection, review model, CODEOWNERS, MiFID II retention, PR templates, merge strategy, onboarding, etc), step by step explanations for our Ratification mechanism and ratification flow and basically any other workflow. We should only do this after we've finished preparing the framework and are ready to fully onboard them. But this should be
+  planned and inserted into the roadmap of our PRs right now.


### PR DESCRIPTION
## Summary

Lands three dispatch artifacts on `main` so the LIMITLESS main-ops Architect can read them from `origin/main` while drafting the 4-topic Phase 2 readiness follow-up PR. Closes the context-fidelity gap flagged on 2026-04-21T13:47Z (Architect could not access the brief sent as a Discord attachment).

Files added:
- `docs/superpowers/specs/SDLC phase 2 readiness report questions.md` — CEO questions to the readiness report (4 topics: agent config governance, Director validation, PM system, onboarding docs)
- `docs/superpowers/specs/2026-04-21-agentic-sdlc-phase-2-readiness-report.md` — Director's Phase 2 readiness report (architecture + DR-001/DR-002 status + @aradSmith greenlight assessment, 9 mermaid diagrams)
- `docs/plans/2026-04-21-architect-handoff-phase-2-questions.md` — Architect handoff brief (4-topic deliverables contract for the follow-up PR)

## Test evidence

No testable change — informational docs only. No `apps/` or `infra/` paths touched; no CI build jobs apply.

## Review checklist

- [x] Change does what the PR title says
- [x] Build and tests pass (no CI affected — docs/ path)
- [x] No unintended side effects on other apps
- [x] No secrets or credentials in diff

🤖 Director-authored — CEO self-ratifies per governance spec §5.3 lighter review checklist for `docs/` path.