### PR TITLE
docs: gitignore hygiene + nanoclaw worktree ownership issue (pre-governance residue)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ TEMP/
 *.pdf
 *.docx
 test-results/
+
+keys/
+*.pem
+*.private-key
+temp/

--- a/docs/superpowers/specs/2026-04-05-nanoclaw-known-issues.md
+++ b/docs/superpowers/specs/2026-04-05-nanoclaw-known-issues.md
@@ -235,6 +235,49 @@ VPS-specific config (not in repo):
 
 ---
 
+---
+
+## 6. Git Worktree Ownership Mismatch in Containers (FIXED)
+
+**Severity:** High — blocked container task execution for all Architects
+**Discovered:** 2026-04-03 (post-Phase-0 deploy verification)
+**Fixed:** Immediate `chown` + deploy rule, no code change required
+
+### Problem
+
+After the Phase 0 monorepo sync, NanoClaw worker containers were failing with git permission errors when attempting to operate on the worktree mounted at `/workspace/extra/monorepo`. The git working tree was owned by `root` (UID 0) while the container process runs as `limitless` (UID 1000). Git refuses to operate on directories it does not own.
+
+```
+fatal: detected dubious ownership in repository at '/workspace/extra/monorepo'
+To add an exception for this directory, call:
+  git config --global --add safe.directory /workspace/extra/monorepo
+```
+
+Even with `safe.directory` workarounds in CLAUDE.md, write operations (`git add`, `git commit`, `git worktree add`) failed because the UID mismatch is enforced at the filesystem level, not just git's safety check.
+
+### Root Cause
+
+Manual SSH operations during Phase 0 setup were run as `root` (direct `sudo su` session), which created worktree directories and git index files owned by UID 0. NanoClaw's systemd service runs as `limitless` (UID 1000) and spawns containers with the same UID. The mismatch was invisible until containers actually attempted write operations.
+
+### Fix
+
+**Immediate:** `chown -R limitless:limitless /home/limitless/projects/limitless` and `/tmp/nanoclaw-worktrees/` to realign all ownership to UID 1000.
+
+**Ongoing deploy rule:** All VPS operations that touch the monorepo or worktree directories must be run as the `limitless` user:
+
+```bash
+# Correct
+sudo -u limitless git -C /home/limitless/projects/limitless pull
+sudo -u limitless npm run build
+
+# Wrong — creates root-owned files in the git index
+sudo git -C /home/limitless/projects/limitless pull
+```
+
+### Why Not a Code Fix
+
+The container-runner could defensively `chown` worktrees after creation, but this would require the NanoClaw process to have `sudo` or `CAP_CHOWN` capability — expanding the attack surface unnecessarily. The correct fix is a process guardrail: never create or modify worktree content as root. This is a deploy-time discipline issue, not a software bug.
+
 ## Tracking
 
 | Issue | Severity | Status | Fix |
@@ -244,3 +287,4 @@ VPS-specific config (not in repo):
 | Director commands don't reach Architect | Medium | **FIXED** | Bot allowlist: TRUSTED_BOT_IDS env var (PR #19) |
 | Stale CLAUDE.md after deploy | Low | **FIXED** | Deploy script now: `rm -rf dist/ && npm run build` + container kill |
 | GH_TOKEN not reaching subagent shells | High | **FIXED** | 3-layer injection: Docker -e → /etc/environment → /etc/bash.bashrc (PR #19) |
+| Git worktree ownership mismatch | High | **FIXED** | UID 1000 alignment confirmed. Deploy rule: never create worktrees as root |


### PR DESCRIPTION
## Summary

Two docs-only changes found on CEO's local clone during 2026-04-22 main-sync cleanup. Content is valid; landing via Architect PR flow per governance spec §4.1.

## Change 1 — `.gitignore`

Append 4 entries after `test-results/`:

```
keys/
*.pem
*.private-key
temp/
```

Covers private key files, PEM certificates, and scratch temp directories that should never be committed.

## Change 2 — `docs/superpowers/specs/2026-04-05-nanoclaw-known-issues.md`

Insert **Section 6: Git Worktree Ownership Mismatch in Containers (FIXED)** immediately before `## Tracking`, covering:
- Problem: containers ran as UID 1000 but worktrees were owned by root (UID 0) after manual SSH operations during Phase 0 setup
- Root cause: VPS setup commands run as root created root-owned git index files
- Fix: `chown -R limitless:limitless` + deploy rule `sudo -u limitless` for all monorepo operations
- Why not a code fix: defensive `chown` in container-runner would require `CAP_CHOWN` — unnecessarily expands attack surface

Also appends one row to the tracking table:
```
| Git worktree ownership mismatch | High | **FIXED** | UID 1000 alignment confirmed. Deploy rule: never create worktrees as root |
```

## Scope

Docs-only. No code changes, no CI impact, no runtime changes.

---

> Authored-by-agent: LIMITLESS infra Architect (governance spec §4.1)