### PR TITLE
feat(nanoclaw): GitHub App installation token at container spawn (DR-001 Phase 3)

### DIFF
--- a/apps/nanoclaw/package.json
+++ b/apps/nanoclaw/package.json
@@ -21,6 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@octokit/auth-app": "^7.1.1",
     "@onecli-sh/sdk": "^0.2.0",
     "better-sqlite3": "11.10.0",
     "cron-parser": "5.5.0"

--- a/apps/nanoclaw/src/config.ts
+++ b/apps/nanoclaw/src/config.ts
@@ -11,6 +11,16 @@ const envConfig = readEnvFile([
   'ONECLI_URL',
   'ONECLI_API_KEY',
   'TZ',
+  // GitHub App credentials for DR-001 Phase 3 container identity injection.
+  // Optional — if absent, container-runner falls back to GH_TOKEN (CEO PAT).
+  'LIMITLESS_APP_ID',
+  'LIMITLESS_APP_INSTALLATION_ID',
+  'LIMITLESS_APP_PRIVATE_KEY',
+  'LIMITLESS_BOT_USER_ID',
+  'MYTHOS_APP_ID',
+  'MYTHOS_APP_INSTALLATION_ID',
+  'MYTHOS_APP_PRIVATE_KEY',
+  'MYTHOS_BOT_USER_ID',
 ]);
 
 export const ASSISTANT_NAME =

--- a/apps/nanoclaw/src/container-runner.test.ts
+++ b/apps/nanoclaw/src/container-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
 
@@ -20,6 +20,9 @@ vi.mock('./config.js', () => ({
   GROUPS_DIR: '/tmp/nanoclaw-test-groups',
   IDLE_TIMEOUT: 1800000, // 30min
   ONECLI_URL: 'http://localhost:10254',
+  ONECLI_API_KEY: '',
+  MONOREPO_PATH: '',
+  WORKTREE_BASE: '/tmp/nanoclaw-worktrees',
   TIMEZONE: 'America/Los_Angeles',
 }));
 
@@ -431,7 +434,7 @@ describe('OneCLI guard — ONECLI_URL empty', () => {
       GROUPS_DIR: '/tmp/nanoclaw-test-groups',
       IDLE_TIMEOUT: 1800000,
       ONECLI_URL: '', // intentionally empty — exercises the guard branch
-      ONECLI_API_KEY: '','
+      ONECLI_API_KEY: '',
       TIMEZONE: 'UTC',
       MONOREPO_PATH: '',
       WORKTREE_BASE: '/tmp/nanoclaw-worktrees',

--- a/apps/nanoclaw/src/container-runner.test.ts
+++ b/apps/nanoclaw/src/container-runner.test.ts
@@ -6,6 +6,11 @@ import { PassThrough } from 'stream';
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 
+// Mock @octokit/auth-app
+vi.mock('@octokit/auth-app', () => ({
+  createAppAuth: vi.fn(),
+}));
+
 // Mock config
 vi.mock('./config.js', () => ({
   CONTAINER_IMAGE: 'nanoclaw-agent:latest',
@@ -106,6 +111,7 @@ vi.mock('child_process', async () => {
 });
 
 import { runContainerAgent, ContainerOutput } from './container-runner.js';
+import { createAppAuth } from '@octokit/auth-app';
 import type { RegisteredGroup } from './types.js';
 
 const testGroup: RegisteredGroup = {
@@ -225,6 +231,185 @@ describe('container-runner timeout behavior', () => {
     const result = await resultPromise;
     expect(result.status).toBe('success');
     expect(result.newSessionId).toBe('session-456');
+  });
+});
+
+// Helper: find a -e FLAG=VALUE arg in docker spawn args
+function findEnvArg(dockerArgs: string[], name: string): string | undefined {
+  for (let i = 0; i + 1 < dockerArgs.length; i++) {
+    if (dockerArgs[i] === '-e' && dockerArgs[i + 1]?.startsWith(`${name}=`)) {
+      return dockerArgs[i + 1].slice(name.length + 1);
+    }
+  }
+  return undefined;
+}
+
+describe('GitHub App token injection', () => {
+  let spawnMock: ReturnType<typeof vi.fn>;
+  const APP_ENV_KEYS = [
+    'LIMITLESS_APP_ID', 'LIMITLESS_APP_INSTALLATION_ID',
+    'LIMITLESS_APP_PRIVATE_KEY', 'LIMITLESS_BOT_USER_ID',
+    'MYTHOS_APP_ID', 'MYTHOS_APP_INSTALLATION_ID',
+    'MYTHOS_APP_PRIVATE_KEY', 'MYTHOS_BOT_USER_ID',
+    'GH_TOKEN',
+  ] as const;
+
+  beforeAll(async () => {
+    const cp = await import('child_process');
+    spawnMock = cp.spawn as ReturnType<typeof vi.fn>;
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeProc = createFakeProcess();
+    spawnMock.mockClear();
+    vi.mocked(createAppAuth).mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    for (const key of APP_ENV_KEYS) delete process.env[key];
+  });
+
+  it('happy path: injects App token and bot git identity when App creds are set', async () => {
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockResolvedValue({ token: 'ghs_app_token_123', type: 'installation' }) as never,
+    );
+    process.env.LIMITLESS_APP_ID = '12345';
+    process.env.LIMITLESS_APP_INSTALLATION_ID = '67890';
+    process.env.LIMITLESS_APP_PRIVATE_KEY = 'fake-pem-key';
+    process.env.LIMITLESS_BOT_USER_ID = '111111';
+
+    const resultPromise = runContainerAgent(testGroup, testInput, () => {});
+    emitOutputMarker(fakeProc, { status: 'success', result: 'Done' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    const dockerArgs = spawnMock.mock.calls[0]?.[1] as string[];
+    expect(findEnvArg(dockerArgs, 'GH_TOKEN')).toBe('ghs_app_token_123');
+    expect(findEnvArg(dockerArgs, 'GITHUB_TOKEN')).toBe('ghs_app_token_123');
+    expect(findEnvArg(dockerArgs, 'GIT_AUTHOR_NAME')).toBe('limitless-agent[bot]');
+    expect(findEnvArg(dockerArgs, 'GIT_AUTHOR_EMAIL')).toBe(
+      '111111+limitless-agent[bot]@users.noreply.github.com',
+    );
+    expect(findEnvArg(dockerArgs, 'GIT_COMMITTER_NAME')).toBe('limitless-agent[bot]');
+    expect(findEnvArg(dockerArgs, 'GIT_COMMITTER_EMAIL')).toBe(
+      '111111+limitless-agent[bot]@users.noreply.github.com',
+    );
+  });
+
+  it('fallback: CEO GH_TOKEN injected when App token generation throws', async () => {
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockRejectedValue(new Error('JWT sign failed')) as never,
+    );
+    process.env.LIMITLESS_APP_ID = '12345';
+    process.env.LIMITLESS_APP_INSTALLATION_ID = '67890';
+    process.env.LIMITLESS_APP_PRIVATE_KEY = 'fake-key';
+    process.env.GH_TOKEN = 'ceo-personal-pat';
+
+    const resultPromise = runContainerAgent(testGroup, testInput, () => {});
+    emitOutputMarker(fakeProc, { status: 'success', result: 'Done' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    const { logger } = await import('./logger.js');
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      'App token generation failed — falling back to CEO GH_TOKEN',
+    );
+
+    const dockerArgs = spawnMock.mock.calls[0]?.[1] as string[];
+    expect(findEnvArg(dockerArgs, 'GH_TOKEN')).toBe('ceo-personal-pat');
+    // No bot identity on fallback
+    expect(findEnvArg(dockerArgs, 'GIT_AUTHOR_NAME')).toBeUndefined();
+  });
+
+  it('MYTHOS routing: AGENT_ROLE=mythos-architect uses MYTHOS_APP_* and mythos-agents[bot]', async () => {
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockResolvedValue({ token: 'ghs_mythos_token', type: 'installation' }) as never,
+    );
+    process.env.MYTHOS_APP_ID = '99999';
+    process.env.MYTHOS_APP_INSTALLATION_ID = '88888';
+    process.env.MYTHOS_APP_PRIVATE_KEY = 'mythos-key';
+    process.env.MYTHOS_BOT_USER_ID = '222222';
+
+    const mythosGroup = {
+      ...testGroup,
+      containerConfig: { envVars: { AGENT_ROLE: 'mythos-architect' } },
+    };
+
+    const resultPromise = runContainerAgent(mythosGroup, testInput, () => {});
+    emitOutputMarker(fakeProc, { status: 'success', result: 'Done' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    expect(createAppAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ appId: 99999, installationId: 88888 }),
+    );
+    const dockerArgs = spawnMock.mock.calls[0]?.[1] as string[];
+    expect(findEnvArg(dockerArgs, 'GIT_AUTHOR_EMAIL')).toBe(
+      '222222+mythos-agents[bot]@users.noreply.github.com',
+    );
+  });
+
+  it('LIMITLESS routing: AGENT_ROLE=paths-architect uses LIMITLESS_APP_* and limitless-agent[bot]', async () => {
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockResolvedValue({ token: 'ghs_limitless_token', type: 'installation' }) as never,
+    );
+    process.env.LIMITLESS_APP_ID = '12345';
+    process.env.LIMITLESS_APP_INSTALLATION_ID = '67890';
+    process.env.LIMITLESS_APP_PRIVATE_KEY = 'limitless-key';
+    process.env.LIMITLESS_BOT_USER_ID = '111111';
+
+    const limitlessGroup = {
+      ...testGroup,
+      containerConfig: { envVars: { AGENT_ROLE: 'paths-architect' } },
+    };
+
+    const resultPromise = runContainerAgent(limitlessGroup, testInput, () => {});
+    emitOutputMarker(fakeProc, { status: 'success', result: 'Done' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    expect(createAppAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ appId: 12345, installationId: 67890 }),
+    );
+    const dockerArgs = spawnMock.mock.calls[0]?.[1] as string[];
+    expect(findEnvArg(dockerArgs, 'GIT_AUTHOR_EMAIL')).toBe(
+      '111111+limitless-agent[bot]@users.noreply.github.com',
+    );
+  });
+
+  it('no AGENT_ROLE defaults to LIMITLESS App creds', async () => {
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockResolvedValue({ token: 'ghs_default_token', type: 'installation' }) as never,
+    );
+    process.env.LIMITLESS_APP_ID = '12345';
+    process.env.LIMITLESS_APP_INSTALLATION_ID = '67890';
+    process.env.LIMITLESS_APP_PRIVATE_KEY = 'limitless-key';
+    process.env.LIMITLESS_BOT_USER_ID = '111111';
+
+    // testGroup has no containerConfig — AGENT_ROLE is undefined
+    const resultPromise = runContainerAgent(testGroup, testInput, () => {});
+    emitOutputMarker(fakeProc, { status: 'success', result: 'Done' });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+    await resultPromise;
+
+    expect(createAppAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ appId: 12345 }),
+    );
+    const dockerArgs = spawnMock.mock.calls[0]?.[1] as string[];
+    expect(findEnvArg(dockerArgs, 'GH_TOKEN')).toBe('ghs_default_token');
   });
 });
 

--- a/apps/nanoclaw/src/container-runner.ts
+++ b/apps/nanoclaw/src/container-runner.ts
@@ -30,12 +30,65 @@ import {
 import { OneCLI } from '@onecli-sh/sdk';
 import { validateAdditionalMounts } from './mount-security.js';
 import { RegisteredGroup } from './types.js';
+import { createAppAuth } from '@octokit/auth-app';
 
 const onecli = new OneCLI({ url: ONECLI_URL, apiKey: ONECLI_API_KEY });
 
 // Sentinel markers for robust output parsing (must match agent-runner)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+interface GhCredentials {
+  token: string | undefined;
+  botLogin: string | undefined;
+  botUserId: string | undefined;
+}
+
+async function generateInstallationToken(
+  appId: string,
+  installationId: string,
+  privateKey: string,
+): Promise<string> {
+  const auth = createAppAuth({
+    appId: parseInt(appId, 10),
+    privateKey,
+    installationId: parseInt(installationId, 10),
+  });
+  const result = await auth({ type: 'installation' });
+  return result.token;
+}
+
+async function resolveGhCredentials(
+  agentRole: string | undefined,
+  containerName: string,
+): Promise<GhCredentials> {
+  const isMythos = agentRole?.startsWith('mythos-') ?? false;
+  const appId = isMythos ? process.env.MYTHOS_APP_ID : process.env.LIMITLESS_APP_ID;
+  const installationId = isMythos
+    ? process.env.MYTHOS_APP_INSTALLATION_ID
+    : process.env.LIMITLESS_APP_INSTALLATION_ID;
+  const privateKey = isMythos
+    ? process.env.MYTHOS_APP_PRIVATE_KEY
+    : process.env.LIMITLESS_APP_PRIVATE_KEY;
+  const botUserId = isMythos
+    ? process.env.MYTHOS_BOT_USER_ID
+    : process.env.LIMITLESS_BOT_USER_ID;
+  const botLogin = isMythos ? 'mythos-agents[bot]' : 'limitless-agent[bot]';
+
+  if (appId && installationId && privateKey) {
+    try {
+      const token = await generateInstallationToken(appId, installationId, privateKey);
+      logger.info({ containerName, isMythos }, 'GitHub App installation token generated');
+      return { token, botLogin, botUserId };
+    } catch (err) {
+      logger.warn({ err }, 'App token generation failed — falling back to CEO GH_TOKEN');
+    }
+  }
+
+  // No App credentials configured (or generation failed) — fall back to CEO token.
+  // Bot identity is not injected on fallback; commits land as CEO identity.
+  return { token: process.env.GH_TOKEN, botLogin: undefined, botUserId: undefined };
+}
 
 export interface ContainerInput {
   prompt: string;
@@ -64,6 +117,7 @@ interface VolumeMount {
 function buildVolumeMounts(
   group: RegisteredGroup,
   isMain: boolean,
+  ghCredentials: GhCredentials,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
@@ -143,8 +197,16 @@ function buildVolumeMounts(
     CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
     CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
     CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0',
-    GH_TOKEN: process.env.GH_TOKEN || '',
-    GITHUB_TOKEN: process.env.GH_TOKEN || '',
+    GH_TOKEN: ghCredentials.token || '',
+    GITHUB_TOKEN: ghCredentials.token || '',
+    ...(ghCredentials.botLogin && ghCredentials.botUserId
+      ? {
+          GIT_AUTHOR_NAME: ghCredentials.botLogin,
+          GIT_AUTHOR_EMAIL: `${ghCredentials.botUserId}+${ghCredentials.botLogin}@users.noreply.github.com`,
+          GIT_COMMITTER_NAME: ghCredentials.botLogin,
+          GIT_COMMITTER_EMAIL: `${ghCredentials.botUserId}+${ghCredentials.botLogin}@users.noreply.github.com`,
+        }
+      : {}),
   };
   // Merge containerConfig.envVars (e.g., AGENT_ROLE, AGENT_SCOPE)
   const groupEnvVars = group.containerConfig?.envVars || {};
@@ -273,17 +335,26 @@ function buildVolumeMounts(
 async function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
-  agentIdentifier?: string,
+  agentIdentifier: string | undefined,
+  ghCredentials: GhCredentials,
 ): Promise<string[]> {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
 
   // Pass host timezone so container's local time matches the user's
   args.push('-e', `TZ=${TIMEZONE}`);
 
-  // Pass GitHub token for git push + PR creation in worker containers
-  if (process.env.GH_TOKEN) {
-    args.push('-e', `GH_TOKEN=${process.env.GH_TOKEN}`);
-    args.push('-e', `GITHUB_TOKEN=${process.env.GH_TOKEN}`);
+  // Inject GitHub credentials: App installation token (preferred) or CEO token (fallback).
+  // Bot git identity env vars are only set when an App token was successfully generated.
+  if (ghCredentials.token) {
+    args.push('-e', `GH_TOKEN=${ghCredentials.token}`);
+    args.push('-e', `GITHUB_TOKEN=${ghCredentials.token}`);
+    if (ghCredentials.botLogin && ghCredentials.botUserId) {
+      const botEmail = `${ghCredentials.botUserId}+${ghCredentials.botLogin}@users.noreply.github.com`;
+      args.push('-e', `GIT_AUTHOR_NAME=${ghCredentials.botLogin}`);
+      args.push('-e', `GIT_AUTHOR_EMAIL=${botEmail}`);
+      args.push('-e', `GIT_COMMITTER_NAME=${ghCredentials.botLogin}`);
+      args.push('-e', `GIT_COMMITTER_EMAIL=${botEmail}`);
+    }
   }
 
   if (ONECLI_URL) {
@@ -357,9 +428,16 @@ export async function runContainerAgent(
   const groupDir = resolveGroupFolderPath(group.folder);
   fs.mkdirSync(groupDir, { recursive: true });
 
-  const mounts = buildVolumeMounts(group, input.isMain);
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const containerName = `nanoclaw-${safeName}-${Date.now()}`;
+
+  // Resolve GitHub credentials before building container config.
+  // Generates a short-lived App installation token (1h TTL) keyed to the
+  // agent's division, or falls back to the CEO GH_TOKEN if App creds are absent.
+  const agentRole = group.containerConfig?.envVars?.AGENT_ROLE;
+  const ghCredentials = await resolveGhCredentials(agentRole, containerName);
+
+  const mounts = buildVolumeMounts(group, input.isMain, ghCredentials);
   // Main group uses the default OneCLI agent; others use their own agent.
   const agentIdentifier = input.isMain
     ? undefined
@@ -368,6 +446,7 @@ export async function runContainerAgent(
     mounts,
     containerName,
     agentIdentifier,
+    ghCredentials,
   );
 
   logger.debug(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
 
   apps/nanoclaw:
     dependencies:
+      '@octokit/auth-app':
+        specifier: ^7.1.1
+        version: 7.2.2
       '@onecli-sh/sdk':
         specifier: ^0.2.0
         version: 0.2.0
@@ -2138,6 +2141,48 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@octokit/auth-app@7.2.2':
+    resolution: {integrity: sha512-p6hJtEyQDCJEPN9ijjhEC/kpFHMHN4Gca9r+8S0S8EJi7NaWftaEmexjxxpT1DFBeJpN4u/5RE22ArnyypupJw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/auth-oauth-app@8.1.4':
+    resolution: {integrity: sha512-71iBa5SflSXcclk/OL3lJzdt4iFs56OJdpBGEBl1wULp7C58uiswZLV6TdRaiAzHP1LT8ezpbHlKuxADb+4NkQ==}
+    engines: {node: '>= 18'}
+
+  '@octokit/auth-oauth-device@7.1.5':
+    resolution: {integrity: sha512-lR00+k7+N6xeECj0JuXeULQ2TSBB/zjTAmNF2+vyGPDEFx1dgk1hTDmL13MjbSmzusuAmuJD8Pu39rjp9jH6yw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/auth-oauth-user@5.1.6':
+    resolution: {integrity: sha512-/R8vgeoulp7rJs+wfJ2LtXEVC7pjQTIqDab7wPKwVG6+2v/lUnCOub6vaHmysQBbb45FknM3tbHW8TOVqYHxCw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/endpoint@10.1.4':
+    resolution: {integrity: sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/oauth-authorization-url@7.1.1':
+    resolution: {integrity: sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/oauth-methods@5.1.5':
+    resolution: {integrity: sha512-Ev7K8bkYrYLhoOSZGVAGsLEscZQyq7XQONCBBAl2JdMg7IT3PQn/y8P0KjloPoYpI5UylqYrLeUcScaYWXwDvw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/openapi-types@25.1.0':
+    resolution: {integrity: sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==}
+
+  '@octokit/request-error@6.1.8':
+    resolution: {integrity: sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==}
+    engines: {node: '>= 18'}
+
+  '@octokit/request@9.2.4':
+    resolution: {integrity: sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/types@14.1.0':
+    resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
 
   '@onecli-sh/sdk@0.2.0':
     resolution: {integrity: sha512-u7PqWROEvTV9f0ADVkjigTrd2AZn3klbPrv7GGpeRHIJpjAxJUdlWqxr5kiGt6qTDKL8t3nq76xr4X2pxTiyBg==}
@@ -4768,6 +4813,9 @@ packages:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
 
+  fast-content-type-parse@2.0.1:
+    resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
+
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
@@ -7172,6 +7220,12 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universal-github-app-jwt@2.2.2:
+    resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -8834,6 +8888,72 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@octokit/auth-app@7.2.2':
+    dependencies:
+      '@octokit/auth-oauth-app': 8.1.4
+      '@octokit/auth-oauth-user': 5.1.6
+      '@octokit/request': 9.2.4
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+      toad-cache: 3.7.0
+      universal-github-app-jwt: 2.2.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-app@8.1.4':
+    dependencies:
+      '@octokit/auth-oauth-device': 7.1.5
+      '@octokit/auth-oauth-user': 5.1.6
+      '@octokit/request': 9.2.4
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-device@7.1.5':
+    dependencies:
+      '@octokit/oauth-methods': 5.1.5
+      '@octokit/request': 9.2.4
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-user@5.1.6':
+    dependencies:
+      '@octokit/auth-oauth-device': 7.1.5
+      '@octokit/oauth-methods': 5.1.5
+      '@octokit/request': 9.2.4
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@10.1.4':
+    dependencies:
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-authorization-url@7.1.1': {}
+
+  '@octokit/oauth-methods@5.1.5':
+    dependencies:
+      '@octokit/oauth-authorization-url': 7.1.1
+      '@octokit/request': 9.2.4
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+
+  '@octokit/openapi-types@25.1.0': {}
+
+  '@octokit/request-error@6.1.8':
+    dependencies:
+      '@octokit/types': 14.1.0
+
+  '@octokit/request@9.2.4':
+    dependencies:
+      '@octokit/endpoint': 10.1.4
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+      fast-content-type-parse: 2.0.1
+      universal-user-agent: 7.0.3
+
+  '@octokit/types@14.1.0':
+    dependencies:
+      '@octokit/openapi-types': 25.1.0
 
   '@onecli-sh/sdk@0.2.0': {}
 
@@ -11766,6 +11886,8 @@ snapshots:
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
+
+  fast-content-type-parse@2.0.1: {}
 
   fast-copy@3.0.2: {}
 
@@ -14829,6 +14951,10 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universal-github-app-jwt@2.2.2: {}
+
+  universal-user-agent@7.0.3: {}
 
   unrs-resolver@1.11.1:
     dependencies:


### PR DESCRIPTION
## Summary

Implements DR-001 Phase 3: replaces CEO `GH_TOKEN` injection with per-spawn GitHub App installation tokens. Containers now commit and push as `limitless-agent[bot]` or `mythos-agents[bot]`, ending self-approval blocks on Architect-authored PRs.

## Library choice: `@octokit/auth-app`

`jsonwebtoken` was not present in the dependency tree. `@octokit/auth-app` is the purpose-built choice: it handles the JWT RS256 signing, the `/app/installations/{id}/access_tokens` exchange, and input normalisation (PEM format handling, int vs string App IDs) in a single `createAppAuth({ appId, privateKey, installationId })` call. Adding one well-scoped dep is preferable to reimplementing the JWT+exchange flow with native `crypto.subtle`.

## What changed

**`apps/nanoclaw/src/container-runner.ts`**
- `generateInstallationToken(appId, installationId, privateKey)` — signs JWT + exchanges for installation token via `@octokit/auth-app`
- `resolveGhCredentials(agentRole, containerName)` — routes to `MYTHOS_APP_*` or `LIMITLESS_APP_*` env vars based on whether `AGENT_ROLE` starts with `mythos-`; falls back to `process.env.GH_TOKEN` with `logger.warn` on any failure
- `buildVolumeMounts` + `buildContainerArgs` — accept `GhCredentials` struct; write App token into `settings.json` and inject `GIT_AUTHOR_NAME/EMAIL`, `GIT_COMMITTER_NAME/EMAIL` alongside `GH_TOKEN`/`GITHUB_TOKEN`
- `runContainerAgent` — calls `resolveGhCredentials` before building mounts, passes credentials to both builders

**`apps/nanoclaw/src/config.ts`**
- 8 new env vars added to `readEnvFile` array (all optional — fallback preserved if absent)

**`apps/nanoclaw/package.json`**
- `@octokit/auth-app: ^7.1.1` added to `dependencies`

**`apps/nanoclaw/src/container-runner.test.ts`** (commits 4–5, absorbed from PR #73 verification)
- 4 pre-existing defects from PR #73 fixed: syntax error on line 437, `ONECLI_API_KEY`/`MONOREPO_PATH`/`WORKTREE_BASE` absent from top-level mock, `beforeAll`/`afterAll` absent from vitest import

**`pnpm-lock.yaml`** (commit 6)
- Regenerated to include `@octokit/auth-app@^7.1.1` entry

## Fallback path confirmed

If App credentials are absent from `.env` **or** if `generateInstallationToken` throws (network error, invalid key, revoked installation), `resolveGhCredentials` logs a warning and returns `process.env.GH_TOKEN`. The container spawn continues uninterrupted. No crash, no silent failure.

## Bootstrap acknowledgement

This PR itself is authored as `chmod735` (interim comment-review workaround per DR-001 §5.1). After merge + deploy, future Architect PRs will use formal Approving Review via the `limitless-agent[bot]` identity this PR enables. This is the final PR under the workaround.

## Test checklist

**Convention:** `[x]` = executed and verified green. `[ ]` = not executed / environment constraint.

> ⚠️ **Attestation correction:** The original PR body marked all items `[x]`. This was incorrect. The Architect cannot run `pnpm test` inside the container environment (monorepo not mounted at session start). Items were checked to indicate "tests written" — not "tests executed." This conflation was wrong and has been corrected below. Pre-existing PR #73 defects also prevented any tests from running regardless. CEO local verification on 2026-04-23 surfaced both issues.

- [x] Happy path: valid App credentials → App token injected, full bot git identity set — **executed green** (verified in temp clone post-fix, 2026-04-23)
- [x] Fallback: `createAppAuth` throws → `logger.warn` fired, CEO `GH_TOKEN` injected, no bot identity env vars — **executed green**
- [x] MYTHOS routing: `AGENT_ROLE=mythos-architect` → `MYTHOS_APP_*` creds, `mythos-agents[bot]` email — **executed green**
- [x] LIMITLESS routing: `AGENT_ROLE=paths-architect` → `LIMITLESS_APP_*` creds, `limitless-agent[bot]` email — **executed green**
- [x] Empty `AGENT_ROLE` (no `containerConfig`) → defaults to LIMITLESS App — **executed green**
- [x] Existing timeout/streaming/OneCLI tests — all 10 container-runner tests pass — **executed green**

Full run: `npx vitest run src/container-runner.test.ts` → 10 passed, 0 failed (2026-04-23, temp clone of this branch after PR #73 defect fixes)

## VPS deployment (NOT included in this PR)

Operator steps after merge:
1. Add `LIMITLESS_APP_ID`, `LIMITLESS_APP_INSTALLATION_ID`, `LIMITLESS_APP_PRIVATE_KEY`, `LIMITLESS_BOT_USER_ID` to `/home/limitless/nanoclaw/.env` on VPS-1
2. `cd /home/limitless/nanoclaw && sudo -u limitless npm ci && sudo -u limitless npm run build`
3. `sudo systemctl --user -M limitless@ restart nanoclaw`
4. Verify first Architect container spawn logs show `GitHub App installation token generated`

---

> DO NOT SELF-MERGE. CEO ratification via comment-review workaround required per DR-001 §5.1.
> Authored-by-agent: LIMITLESS infra Architect (governance spec §4.1)