### PR TITLE
docs: 2026-04-25 Meridian-diff incident arc — SDK contract spec + plans + retro

### DIFF
--- a/docs/superpowers/handoffs/2026-04-25-shadow-architect-oauth-research-handoff.md
+++ b/docs/superpowers/handoffs/2026-04-25-shadow-architect-oauth-research-handoff.md
@@ -1,0 +1,210 @@
+---
+status: OPEN — research-only handoff (NO ACTIONS)
+intended-recipient: OpenClaw Director (`openai-codex/gpt-5.5`, in #main-ops, TUI-accessible)
+authority: ANALYSIS ONLY. Do NOT modify code, config, secrets, deployments, or any other state. Do NOT direct other agents. Do NOT take or recommend irreversible actions. Output is text-only — Discord reply to Director (CC session) and/or markdown summary.
+created: 2026-04-25T15:50Z
+priority: P0 (CEO directive: shadow architect operational TODAY via OAuth, not settling for less)
+related-incident: project_2026-04-25_meridian_diff_and_streaming_bug.md
+related-spec: docs/superpowers/specs/2026-04-25-sdk-contract-proxy-as-interop-layer.md
+related-PR: #109 (incident-arc bundle)
+---
+
+# Research Handoff — Shadow Architect Operational via OAuth Today
+
+## CEO directive (verbatim)
+
+> "I want a fully functional shadow architect running nanoclaw v2 working today using OAuth. We're not settling for anything less. Task the openclaw director to go over your work and find another option."
+
+This handoff dispatches that directive to OpenClaw Director for **research only**. Director (CC session) has been working the problem for ~24h+ and has hit a wall — the empirical findings are documented below. CEO wants a second-pair-of-eyes pass on whether there's a path forward that Director missed.
+
+## What "operational" means
+
+A shadow Architect (running on shadow v2 at `/home/limitless/nanoclaw-v2/` on VPS-1, OR via the prod fleet bypass) that can:
+
+1. Receive a Director-handoff in Discord (~2,000-3,000 chars)
+2. Read project files (multi-tool-use, multiple LLM turns)
+3. Author a small PR (read → analyze → edit → typecheck → build → push → open PR)
+4. Post the PR URL back to the dispatching channel
+5. **Without dying mid-flow at code 137 with no result emission**
+
+Trivial single-turn tasks (`@Architect ack` → `Acknowledged.`) currently work. Multi-turn engineering tasks (the actual product) currently do not.
+
+## Constraint: must be OAuth, not API key
+
+CEO is firm: **OAuth subscription token (`sk-ant-oat01-...`)**, not API key (`sk-ant-api01-...`). Reasons explicit and implicit:
+- Existing infrastructure (OneCLI vault, prod fallback path, agent-runner) is built around `CLAUDE_CODE_OAUTH_TOKEN`
+- Cost: Max subscription is flat-rate vs. metered API
+- Auditability: ChatGPT-Plus and Claude-Max OAuth flows are the canonical claude-code path
+- Strategic: don't fork-on-auth at the same time we're recovering the fleet
+
+If the only working answer is API key, we want to know that — but it must be argued, not assumed.
+
+## What Director (CC session) has tried + each one's failure mode
+
+### Path A — OneCLI in front (current pre-bypass posture)
+
+- OneCLI (Rust gateway, `apps/gateway/src/inject.rs:154-170`) injects `x-api-key: <oauth-token>` for `api.anthropic.com` AND removes any `Authorization` header
+- claude-agent-sdk operates against OneCLI's MITM-intercepted upstream
+- **Failure mode:** OneCLI's MITM proxy disconnects ~3 sec into SSE streaming responses. Logs show `MITM method=POST .../v1/messages?beta=true status=200 content_type=text/event-stream` immediately followed by `WARN connection error host=api.anthropic.com:443 error=serving MITM connection` ~3-7 sec later
+- **Result:** short responses (<3 sec) succeed; longer responses truncate mid-stream
+
+### Path B — OneCLI bypass (current prod posture, applied 2026-04-25T15:13Z)
+
+- `ONECLI_URL` commented in `/home/limitless/nanoclaw/.env` (backup at `.env.backup-2026-04-25-bypass-onecli`)
+- Container-runner's existing fallback at `apps/nanoclaw/src/container-runner.ts:401-417` injects `CLAUDE_CODE_OAUTH_TOKEN` directly via `-e`
+- claude-agent-sdk constructs native `Authorization: Bearer <oauth-token>` + coherent `anthropic-beta: oauth-2025-04-20,...` headers
+- No MITM layer — direct connection to api.anthropic.com
+- **Failure mode (just discovered):** every container that does non-trivial work emits `rate_limit_event` after exactly 2 assistant turns, then dies at code 137 BEFORE emitting a `result` message:
+
+```
+[msg #1] type=system/init
+[msg #2] type=assistant
+[msg #3] type=assistant
+[msg #4] type=rate_limit_event   ← warning fired mid-flow
+[msg #5] type=user                ← next-message triggered
+→ exit 137, no `result` emitted
+```
+
+Tiny tasks (`ack`) sneak through because they happen to emit `subtype=success` BEFORE the rate-limit-event-induced exit. Real engineering work doesn't.
+
+### Path C — Cursor drain + fresh session
+
+- Stopped service, advanced cursors in `/home/limitless/nanoclaw/store/messages.db` `router_state.last_agent_timestamp` to NOW for all 6 chat IDs, deleted poisoned session row from `sessions` table, moved poisoned `.jsonl` aside
+- Service restarted clean
+- **Failure mode:** Same as Path B. Fresh session, same 2-turn ceiling.
+
+## Director's working hypothesis
+
+**Claude Max OAuth subscription enforces a ~2-LLM-turns-per-session ceiling before `rate_limit_event` fires.** The SDK then enters a graceful-exit subroutine — emits any in-flight result and exits the subprocess. If the agent is mid-task (no formed final response yet), there's no result to emit, so it just dies at 137.
+
+Discriminator empirically observed:
+- Shadow v2 (`OneCLI mode, same OAuth token`) returned `OK` to `say only the word OK` at 15:11Z — so the token is valid, quota is fine, account is fine
+- Fleet `ack` (bypass mode, same OAuth token) succeeded at 15:16Z because tiny task → `subtype=success` emitted in the brief 2-turn window
+- Both modes share an after-2-turns rate_limit_event signal, but differ in:
+  - OneCLI mode: result still emits because OneCLI's `x-api-key` injection appears to give Anthropic a "this is API-class access, allow more turns" signal  
+  - Bypass mode: real native `Authorization: Bearer` with OAuth token = Anthropic enforces strict subscription-tier per-session ceiling = no follow-on turns after rate_limit
+
+If this hypothesis is correct, **no amount of code-level fixes makes OAuth-direct mode work for real engineering tasks**. The subscription tier itself caps it.
+
+## What Director needs from OpenClaw
+
+**Find a fourth path.** Specifically research, do NOT execute, the following angles:
+
+### Q1 — SDK / Claude Code config that extends per-session ceiling
+
+Is there an env var, SDK option, or Claude Code CLI flag that:
+- Disables the 2-turn rate-limit-event heuristic?
+- Configures the SDK to not exit subprocess on rate-limit-event?
+- Increases per-session turn budget?
+- Changes auth handshake to skip subscription-tier gating?
+
+Inspect:
+- `@anthropic-ai/claude-agent-sdk@0.2.119` source
+- `@anthropic-ai/claude-code@2.1.119` CLI entry points
+- Available env vars (`CLAUDE_*`, `ANTHROPIC_*`)
+- The `-e` flag set the SDK respects
+
+### Q2 — Alternative MITM-free credential-injection middleware
+
+If OneCLI's MITM-induced streaming death is the only blocker for OneCLI-mode (Path A), find alternatives that do credential injection WITHOUT terminating SSE streams. Candidates worth checking:
+
+- **LiteLLM proxy** (`https://github.com/BerriAI/litellm`) — proxy routing with credential injection; has Anthropic adapter
+- **mitmproxy with custom filter** — mature streaming SSE support
+- **Envoy + ext_authz** — production-grade
+- **Cloudflare Workers** — edge-injection without local MITM
+- **Raw nginx with subrequest** — minimal, well-understood streaming behavior
+- **Direct Cloudflare AI Gateway** — has Anthropic support
+- **Other?** OpenClaw should suggest based on its knowledge of the OSS landscape
+
+For each candidate: does it support OAuth-token-as-x-api-key injection (since that's the working path for high turn counts)? Does it preserve streaming SSE without 3-sec disconnects?
+
+### Q3 — OAuth token exchange / sidechannel that elevates per-session limits
+
+Is there a way to take an `sk-ant-oat01-` OAuth token and use it in a mode that gives API-class rate limits instead of subscription-class? E.g.:
+
+- A `?upgrade=api` query parameter
+- A different `anthropic-version` header value
+- An `anthropic-billing` or similar header that signals API-class billing
+- An OAuth scope upgrade
+- Direct token-exchange via Anthropic's auth endpoints
+
+Look at:
+- Anthropic's OAuth docs (consumer subscription vs. business/API)
+- Claude.ai's own client behavior (what headers does claude.ai send?)
+- claude-code SDK's auth path source
+- Meridian's behavior (it's a working OAuth-proxy reference)
+
+### Q4 — Meridian as a drop-in replacement for OneCLI?
+
+Meridian (`https://github.com/rynfar/meridian`) is the working reference implementation Director used to find the SDK contract. It IS an OAuth-aware proxy. Two questions:
+
+- Could Meridian replace OneCLI entirely in our setup? (run Meridian, point `ANTHROPIC_BASE_URL` to it, get its credential filtering + billing-protection without OneCLI's MITM streaming bug)
+- Does Meridian have a "subscription-class-vs-API-class" toggle relevant to Q3?
+
+### Q5 — Per-account configuration on Anthropic Console
+
+Is there a per-account setting (e.g., on `console.anthropic.com` or via support) that uplifts an OAuth subscription's per-session limits? Search:
+- Anthropic billing docs
+- Account dashboard
+- Support kb
+
+### Q6 — Workaround via container-side claude-code config
+
+Inside the agent-runner container, claude-code has a `.claude/settings.json`. Are there settings there that affect rate-limit handling? Auto-retry-on-rate-limit? Per-session-budget?
+
+Inspect: `/home/limitless/nanoclaw/data/sessions/discord_*/.claude/settings.json` — what's currently set vs. what could be set.
+
+## Output format
+
+Deliver back to Director (CC session) via:
+
+1. **Discord reply** to #main-ops with executive summary (~300-500 words):
+   - 1-2 sentence answer: "the path is X" or "no path found, recommend Y"
+   - Top 3 candidate paths ranked
+   - Confidence + biggest uncertainty
+2. **Markdown file** at `/home/limitless/.openclaw/workspace/docs/superpowers/proposals/2026-04-25-shadow-architect-oauth-research-response.md` with:
+   - Detailed findings per question Q1-Q6
+   - Empirical evidence cited (file paths, doc URLs, log excerpts)
+   - Specific recommendations
+   - Estimated time-to-implement for top recommendation
+
+## Constraints — STRICT
+
+OpenClaw must:
+- ❌ NOT modify code, config, env vars, secrets, OneCLI vault, deployments
+- ❌ NOT execute installs, restarts, builds
+- ❌ NOT direct other agents (no IPC, no Discord cross-channel directives)
+- ❌ NOT post GitHub PRs, issues, or comments
+- ❌ NOT take any irreversible action
+
+OpenClaw MAY:
+- ✅ Read public web resources (Anthropic docs, GitHub, npm, Discord)
+- ✅ Read local files on its workspace + `/home/limitless/nanoclaw/`, `/home/limitless/nanoclaw-v2/`, OneCLI source at `/tmp/onecli-ref/` if Director has cached it
+- ✅ Run read-only inspection commands (`docker run --entrypoint cat`, `npm view`, `git log`, `grep`, `curl --head`)
+- ✅ Reason about findings + cross-reference Meridian source if cached at `/tmp/meridian-ref/`
+- ✅ Output a recommendation back to Director
+
+Per `feedback_governance_determinism_primacy.md` and the bot-feedback-loop incident report (PR #82), all Director-class bot agents (including OpenClaw Director gpt-5.5) operate under analysis-only constraint until DR-003 ratifies bot directive authority. **This handoff respects that constraint.**
+
+## Time pressure
+
+CEO wants this resolved TODAY. OpenClaw's research budget is implicitly bounded by that timeline — prioritize depth over breadth, ship a partial answer fast rather than a perfect answer slow. If the analysis genuinely needs more than ~1-2 hours, surface a "still investigating, here's what's confirmed so far" status update to Director's session via Discord reply, so the work stays visible.
+
+## Reference list
+
+- Topic file: `project_2026-04-25_meridian_diff_and_streaming_bug.md` (CC auto-memory)
+- Spec: `docs/superpowers/specs/2026-04-25-sdk-contract-proxy-as-interop-layer.md` (PR #109)
+- OneCLI source clone: `/tmp/onecli-ref/` (if still present after /tmp wipe; else re-clone `https://github.com/onecli/onecli`)
+- Meridian source: `/tmp/meridian-ref/` (or re-clone `https://github.com/rynfar/meridian`)
+- Anthropic prompt-caching + auth docs: `https://docs.anthropic.com/api/`
+- claude-agent-sdk on npm: `https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk`
+- Prod NanoClaw `.env` (read-only inspection): `/home/limitless/nanoclaw/.env` (currently with `ONECLI_URL` commented)
+- Prod sessions dir: `/home/limitless/nanoclaw/data/sessions/discord_*/` (one set per group)
+- Prod messages DB: `/home/limitless/nanoclaw/store/messages.db`
+- Prod NanoClaw service: `systemctl status nanoclaw.service` (currently active, idle)
+
+## Director's standing assumption to challenge
+
+Director currently believes the problem is structural (OAuth subscription tier per-session ceiling) and that the only ways out are (a) revert to OneCLI mode + accept short-task-only fleet, (b) switch to API key, or (c) wait. **CEO has rejected all three.** OpenClaw's job is to find what Director missed — a fourth path.
+
+If after thorough research no fourth path exists and the directive is genuinely impossible today, that finding ALSO has value — but only if argued rigorously with evidence, not asserted.

--- a/docs/superpowers/handoffs/2026-04-25-v2-claude-provider-conditional-system-prompt-refactor.md
+++ b/docs/superpowers/handoffs/2026-04-25-v2-claude-provider-conditional-system-prompt-refactor.md
@@ -1,0 +1,444 @@
+---
+name: NanoClaw v2 — refactor claude.ts to Meridian-shaped conditional resolveSystemPrompt
+status: HANDOFF (ready for execution)
+authored-by: Director (CC session)
+intended-recipient: Infra Architect (or Director hand-applied with CEO ratification)
+authority: ACTIONS ALLOWED (Phase 0 SDK Compliance follow-up; small surgical change)
+incident-arc: project_2026-04-25_meridian_diff_and_streaming_bug.md
+created: 2026-04-25
+priority: P1 (closes "Meridian-shaped but unconditional" quick-fix from 2026-04-25)
+related-specs: 2026-04-25-sdk-contract-proxy-as-interop-layer.md (binding)
+related-handoffs: 2026-04-25-nanoclaw-v2-phase-0-sdk-compliance-handoff.md (this is a slice of Phase 0)
+applies-to: /home/limitless/nanoclaw-v2/container/agent-runner/src/providers/claude.ts on VPS-1
+---
+
+# Handoff: v2 ClaudeProvider — conditional `resolveSystemPrompt`
+
+## Problem
+
+The 2026-04-25 quick-fix to v2's `ClaudeProvider.query()` set:
+
+```typescript
+systemPrompt: instructions || undefined,
+settingSources: [],
+```
+
+This unblocks shadow v2 (avoids the `claude_code` preset emitting
+beta-gated cache fields like `cache_control.ephemeral.scope` and
+`context_management`) but is "Meridian-shaped but unconditional".
+
+Meridian's contract surface (`src/proxy/query.ts:157`) makes the preset
+CONDITIONAL on operator opt-in, with sensible defaults. v2 should adopt
+the same shape so future work that needs the preset (e.g., auto-memory,
+settings loading) can opt in without re-introducing the cache-fields
+problem on default code paths.
+
+The binding spec for why this matters:
+`docs/superpowers/specs/2026-04-25-sdk-contract-proxy-as-interop-layer.md`.
+
+## Reference contract — Meridian's `resolveSystemPrompt`
+
+From `/tmp/meridian-ref/src/proxy/query.ts:157` (clone of
+`https://github.com/rynfar/meridian` — to be re-cloned by Architect if
+local /tmp wiped):
+
+```typescript
+function resolveSystemPrompt(
+  systemContext: string | undefined,
+  passthrough: boolean,
+  settingSources: SettingSource[] | undefined,
+  codeSystemPrompt: boolean | undefined,
+  clientSystemPrompt: boolean | undefined,
+  cwdNote: string,
+): { systemPrompt?: string | { type: "preset"; preset: "claude_code"; append?: string } } {
+  const hasSettings = settingSources != null && settingSources.length > 0
+  const usePreset = codeSystemPrompt ?? (hasSettings || (!passthrough && !!systemContext))
+  const includeClient = clientSystemPrompt ?? true
+  const clientContext = includeClient ? systemContext : undefined
+  const append = [clientContext, cwdNote].filter(Boolean).join("") || undefined
+
+  if (usePreset) {
+    return append
+      ? { systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append } }
+      : { systemPrompt: { type: "preset" as const, preset: "claude_code" as const } }
+  }
+  if (append) return { systemPrompt: append }
+  return {}
+}
+```
+
+Key insights:
+1. **`usePreset` is the gating decision.** Defaults to "preset if settings
+   are loaded OR (we're not in passthrough AND we have systemContext)".
+   Operator can override via `codeSystemPrompt` flag.
+2. **Three return shapes:** `{ preset + append }`, `{ preset alone }`,
+   `{ string append }`, `{}`. Each path uses a different SDK code path.
+3. **The `passthrough` knob** is Meridian-specific (proxy mode flag).
+   v2 doesn't have passthrough mode — that argument simplifies to false
+   in our adaptation.
+4. **`clientSystemPrompt`** lets clients suppress their own systemContext
+   from the SDK call. v2 doesn't have a separate client/server context
+   distinction yet — argument simplifies away.
+5. **`cwdNote`** is for proxy-as-network-relay use case where SDK
+   subprocess CWD ≠ client CWD. v2 runs SDK in-container at the same
+   CWD — argument simplifies to empty string.
+
+## Adapted contract for v2
+
+V2's surface is simpler than Meridian's. Adapted signature:
+
+```typescript
+type SettingSource = 'user' | 'project' | 'local';
+
+interface ResolvedSystemPrompt {
+  systemPrompt?: string | { type: 'preset'; preset: 'claude_code'; append?: string };
+  settingSources?: SettingSource[];
+}
+
+/**
+ * Resolve `systemPrompt` + `settingSources` SDK options from operator opt-in.
+ *
+ * Meridian-shaped: the `claude_code` preset is OPT-IN. The default
+ * (no preset, empty settingSources) avoids the SDK emitting cacheable
+ * system blocks with beta-gated fields like `cache_control.ephemeral.scope`
+ * — which our OAuth-mode auth doesn't currently support.
+ *
+ * Per spec: docs/superpowers/specs/2026-04-25-sdk-contract-proxy-as-interop-layer.md
+ *
+ * Decision tree:
+ *  - usePreset === true: emit `{ type: 'preset', preset: 'claude_code', append? }`
+ *    + pass settingSources through. Use this when you NEED memory / settings
+ *    loading / cacheable system blocks AND have validated the relevant betas
+ *    are enabled for your auth mode.
+ *  - usePreset === undefined (default): no preset. systemContext goes as
+ *    plain string; settingSources stays explicit `[]`. Safe default for
+ *    OAuth-mode subscriptions on current Anthropic API.
+ *  - usePreset === false: same as default but explicit.
+ */
+function resolveSystemPrompt(
+  systemContext: string | undefined,
+  settingSources: SettingSource[] | undefined,
+  usePreset: boolean | undefined,
+): ResolvedSystemPrompt {
+  const hasSettings = settingSources != null && settingSources.length > 0;
+  const shouldUsePreset = usePreset ?? hasSettings;
+  const append = systemContext || undefined;
+
+  if (shouldUsePreset) {
+    const result: ResolvedSystemPrompt = {
+      systemPrompt: append
+        ? { type: 'preset', preset: 'claude_code', append }
+        : { type: 'preset', preset: 'claude_code' },
+    };
+    if (settingSources && settingSources.length > 0) {
+      result.settingSources = settingSources;
+    }
+    return result;
+  }
+
+  if (append) {
+    return { systemPrompt: append, settingSources: [] };
+  }
+  return { settingSources: [] };
+}
+```
+
+## File-level change set
+
+### Change 1 — extend `types.ts` `ProviderOptions`
+
+**File:** `/home/limitless/nanoclaw-v2/container/agent-runner/src/providers/types.ts`
+
+Append to `ProviderOptions`:
+
+```typescript
+/**
+ * SDK setting sources to load (user/project/local). When non-empty,
+ * implies the `claude_code` preset (via resolveSystemPrompt) unless
+ * `usePreset` is set to false explicitly.
+ *
+ * Default `undefined`: no settings loaded; SDK takes minimal-default
+ * code path. Matches Meridian's contract where settings are opt-in.
+ */
+settingSources?: Array<'user' | 'project' | 'local'>;
+
+/**
+ * Override for the `claude_code` preset decision. Default behavior:
+ * preset is enabled when `settingSources` is non-empty. Set explicitly
+ * when caller wants to force the preset without loading settings, or
+ * disable the preset even when settings are loaded.
+ */
+usePreset?: boolean;
+```
+
+### Change 2 — refactor `claude.ts` `ClaudeProvider`
+
+**File:** `/home/limitless/nanoclaw-v2/container/agent-runner/src/providers/claude.ts`
+
+#### 2a — add the `resolveSystemPrompt` helper
+
+Add at module scope (after the existing helper functions, before `ClaudeProvider` class):
+
+```typescript
+type SettingSource = 'user' | 'project' | 'local';
+
+interface ResolvedSystemPrompt {
+  systemPrompt?: string | { type: 'preset'; preset: 'claude_code'; append?: string };
+  settingSources?: SettingSource[];
+}
+
+/**
+ * Meridian-shaped resolver — see docs/superpowers/specs/
+ * 2026-04-25-sdk-contract-proxy-as-interop-layer.md for the contract this
+ * implements. Default code path avoids the `claude_code` preset (which
+ * emits cacheable system blocks with beta-gated fields).
+ */
+function resolveSystemPrompt(
+  systemContext: string | undefined,
+  settingSources: SettingSource[] | undefined,
+  usePreset: boolean | undefined,
+): ResolvedSystemPrompt {
+  const hasSettings = settingSources != null && settingSources.length > 0;
+  const shouldUsePreset = usePreset ?? hasSettings;
+  const append = systemContext || undefined;
+
+  if (shouldUsePreset) {
+    const result: ResolvedSystemPrompt = {
+      systemPrompt: append
+        ? { type: 'preset', preset: 'claude_code', append }
+        : { type: 'preset', preset: 'claude_code' },
+    };
+    if (settingSources && settingSources.length > 0) {
+      result.settingSources = settingSources;
+    }
+    return result;
+  }
+
+  if (append) {
+    return { systemPrompt: append, settingSources: [] };
+  }
+  return { settingSources: [] };
+}
+```
+
+#### 2b — update `ClaudeProvider` constructor + query
+
+Constructor — add fields:
+
+```typescript
+private settingSources?: SettingSource[];
+private usePreset?: boolean;
+
+constructor(options: ProviderOptions = {}) {
+  this.assistantName = options.assistantName;
+  this.mcpServers = options.mcpServers ?? {};
+  this.additionalDirectories = options.additionalDirectories;
+  this.settingSources = options.settingSources;
+  this.usePreset = options.usePreset;
+  this.env = {
+    ...(options.env ?? {}),
+    CLAUDE_CODE_AUTO_COMPACT_WINDOW,
+  };
+}
+```
+
+Query method — replace the unconditional `systemPrompt` + `settingSources` lines:
+
+**Before:**
+```typescript
+const sdkResult = sdkQuery({
+  prompt: stream,
+  options: {
+    cwd: input.cwd,
+    additionalDirectories: this.additionalDirectories,
+    resume: input.continuation,
+    pathToClaudeCodeExecutable: '/pnpm/claude',
+    systemPrompt: instructions || undefined,
+    allowedTools: TOOL_ALLOWLIST,
+    disallowedTools: SDK_DISALLOWED_TOOLS,
+    env: this.env,
+    permissionMode: 'bypassPermissions',
+    allowDangerouslySkipPermissions: true,
+    settingSources: [],
+    mcpServers: this.mcpServers,
+    hooks: { /* ... */ },
+  },
+});
+```
+
+**After:**
+```typescript
+const resolved = resolveSystemPrompt(instructions, this.settingSources, this.usePreset);
+
+const sdkResult = sdkQuery({
+  prompt: stream,
+  options: {
+    cwd: input.cwd,
+    additionalDirectories: this.additionalDirectories,
+    resume: input.continuation,
+    pathToClaudeCodeExecutable: '/pnpm/claude',
+    ...resolved,
+    allowedTools: TOOL_ALLOWLIST,
+    disallowedTools: SDK_DISALLOWED_TOOLS,
+    env: this.env,
+    permissionMode: 'bypassPermissions',
+    allowDangerouslySkipPermissions: true,
+    mcpServers: this.mcpServers,
+    hooks: { /* ... unchanged ... */ },
+  },
+});
+```
+
+The spread `...resolved` injects `systemPrompt` (when present) and
+`settingSources` (when present). Note: `settingSources` MUST be removed
+from its old position to avoid double-keys / unintended overrides.
+
+### Change 3 — call sites
+
+ClaudeProvider is registered via:
+
+```typescript
+registerProvider('claude', (opts) => new ClaudeProvider(opts));
+```
+
+Existing call sites pass the v2 default ProviderOptions (no settings, no
+preset opt-in). Behavior is unchanged for default callers. Call sites
+that NEED the preset (none in current v2 codebase) opt in explicitly:
+
+```typescript
+new ClaudeProvider({ ...baseOpts, usePreset: true, settingSources: ['project', 'user'] });
+```
+
+No call-site changes needed for this PR. Audit:
+
+```bash
+grep -rn 'ClaudeProvider\|registerProvider.*claude' /home/limitless/nanoclaw-v2/
+```
+
+If any caller assumed the unconditional `systemPrompt` shape, this audit
+catches it.
+
+## Verification
+
+### Pre-merge
+
+1. **Typecheck:** `cd /home/limitless/nanoclaw-v2/container/agent-runner && pnpm run typecheck`
+2. **Build:** `pnpm run build` (in agent-runner) + image rebuild for the
+   container (`/home/limitless/nanoclaw-v2/scripts/build-container.sh`
+   or equivalent — verify exact path on VPS-1)
+3. **Default-path round-trip** on shadow v2:
+   - Short prompt: ~3 sec, completes
+   - Medium prompt: ~10 sec, completes
+   - Verify no `cache_control.ephemeral.scope` 400 from Anthropic
+4. **Preset-path round-trip** (opt-in test):
+   - Configure a test agent-runner instance with
+     `usePreset: true, settingSources: ['project']`
+   - Confirm the SDK call constructs the preset shape (visible in
+     OneCLI MITM logs as `systemPrompt: { type: 'preset', ... }`)
+   - **Expected to fail with 400 today** (since preset re-emits
+     cache_control.scope) — that's correct, opt-in is gated on enabling
+     `prompt-caching-scope-2026-01-05` beta and validating in the
+     Phase 0 compatibility matrix.
+
+The default path passing + preset path failing-as-expected confirms the
+refactor is semantically correct (gates the cache fields behind
+operator opt-in) and that no caller is silently broken.
+
+### Post-merge
+
+- Shadow v2 service restart confirms hot-path stability
+- 5-test functional matrix from the streaming-bug fallback plan
+  (`2026-04-25-v2-streaming-bug-onecli-fallback-patch.md`) re-runs
+  cleanly with the conditional config
+
+## PR shape
+
+**Branch:** `refactor/v2-claude-provider-conditional-system-prompt`
+
+**Title:** `refactor(nanoclaw-v2): Meridian-shaped conditional resolveSystemPrompt in ClaudeProvider`
+
+**Body:**
+
+```
+## Problem
+2026-04-25 quick-fix set systemPrompt + settingSources unconditionally
+to avoid the SDK's claude_code preset emitting beta-gated cache fields.
+Meridian-shaped but unconditional — closes the quick-fix into a proper
+contract surface.
+
+## Change
+1. Extend ProviderOptions with `settingSources?` and `usePreset?` opt-ins
+2. Add Meridian-shaped `resolveSystemPrompt` helper
+3. Refactor `ClaudeProvider.query` to use the helper
+
+## Default behavior
+Unchanged — no preset, no settings. Safe for OAuth-mode subscriptions on
+current Anthropic API.
+
+## Opt-in path
+Future callers needing memory / settings loading set
+`usePreset: true, settingSources: [...]` on construction. Gated on
+the Phase 0 compatibility matrix validating the relevant betas for
+our auth mode.
+
+## Spec
+docs/superpowers/specs/2026-04-25-sdk-contract-proxy-as-interop-layer.md
+
+## §5.5 attestation
+Pre-merge: typecheck clean, build clean, default-path 3-test round-trip
+on shadow v2 (short, medium, tool-use) passes, preset-path round-trip
+fails-as-expected confirming gating semantics.
+Post-merge: 5-test functional matrix re-runs clean.
+
+## Related
+- Topic: project_2026-04-25_meridian_diff_and_streaming_bug.md
+- Phase 0 handoff: 2026-04-25-nanoclaw-v2-phase-0-sdk-compliance-handoff.md
+- Streaming-bug plan: 2026-04-25-v2-streaming-bug-onecli-fallback-patch.md
+```
+
+## Risks + mitigation
+
+| Risk | Mitigation |
+|---|---|
+| TypeScript SDK option types changed between v2's pinned 0.2.119 and Meridian's reference version | Empirical: typecheck must pass post-edit. SDK type def confirms `settingSources?: SettingSource[]` and `systemPrompt?: string | { type: 'preset'; preset: 'claude_code'; append?: string }` are the current shape on 0.2.119. |
+| Spread order matters — `...resolved` spread MUST NOT be overridden by later keys | Code review checks no `systemPrompt` or `settingSources` keys exist after the spread |
+| Caller using `usePreset: true` re-introduces cache_control.scope 400 | Documented as expected behavior. Opt-in is gated on Phase 0 compatibility matrix. Default path stays safe. |
+| `claude_code` preset has additional behaviors beyond cache field emission (auto-memory, etc.) — opt-in callers must understand | Inline JSDoc on `usePreset` + `settingSources` documents the trade-off |
+
+## Out of scope
+
+- Validating which betas enable cache_control.scope for OAuth auth.
+  That's Phase 0 Deliverable 0.1-0.2 work (SDK Compliance Brief +
+  Compatibility Matrix). This refactor produces the contract surface;
+  Phase 0 produces the operational knowledge.
+- Adding analogous helpers for other providers (codex, mock). v2's
+  ClaudeProvider is the only one currently emitting the problematic
+  fields.
+- Changing the `passthrough` semantics. v2 doesn't have a passthrough
+  mode; if/when one is added, the helper signature gains `passthrough`
+  arg as Meridian's does.
+
+## Definition of done
+
+- [ ] Patch applied to v2 `types.ts` + `claude.ts` on a feature branch
+- [ ] `pnpm run typecheck` clean in agent-runner
+- [ ] `pnpm run build` clean
+- [ ] Container image rebuild succeeds
+- [ ] Default-path 3-test round-trip on shadow v2 passes
+- [ ] Preset-path opt-in test fails-as-expected (confirms gating)
+- [ ] PR opened, §5.5 attestation in body, formal Approving Review per
+      ruleset 15502000, squash-merge
+- [ ] Topic file `project_2026-04-25_meridian_diff_and_streaming_bug.md`
+      updated to mark "Meridian-shaped but unconditional" as RESOLVED
+
+## Suggested executor
+
+Infra Architect — same scope as Phase 0 SDK Compliance, intimate v2
+codebase knowledge, owns shadow v2 install on VPS-1. Dispatch via
+#infra-eng once Architect fleet is operational under either Phase 0
+SDK compliance OR the streaming-bug fallback patch (whichever
+restores Architects first).
+
+If hand-applied by Director with CEO ratification: scope is small +
+surgical, test surface is clear, risk is low. Acceptable interim path
+if fleet stays down longer than ~24 hours.

--- a/docs/superpowers/plans/2026-04-25-nanoclaw-v2-sdk-compliance-checklist.md
+++ b/docs/superpowers/plans/2026-04-25-nanoclaw-v2-sdk-compliance-checklist.md
@@ -1,0 +1,390 @@
+# NanoClaw v2 Anthropic Agent SDK Compliance Checklist + Test Matrix
+
+Date: 2026-04-25
+Author: LIMITLESS Director
+Status: Draft, research + planning only
+Scope: NanoClaw v2 shadow instance on VPS-1
+
+## 1. Purpose
+
+NanoClaw v2 should be treated as a fresh baseline, not as a patched continuation of v1. Before LIMITLESS reintroduces v1 customizations, v2 must be proven compliant with the current Anthropic Agent SDK / Claude Code expectations for prompt construction, prompt caching, beta headers, auth, and streaming.
+
+This document is a text-only planning artifact. It does not authorize code changes, config changes, deploys, restarts, or agent directives.
+
+## 2. Current Working Diagnosis
+
+The observed v2 failure:
+
+```text
+system.2.cache_control.ephemeral.scope: Extra inputs are not permitted
+```
+
+indicates that a system prompt block includes:
+
+```json
+"cache_control": { "type": "ephemeral", "scope": "..." }
+```
+
+and the Anthropic API route handling the request is rejecting `scope` as an unknown field.
+
+Current evidence suggests this is not a NanoClaw streaming failure and not a basic auth failure. It is most likely an SDK/API beta compatibility issue:
+
+- `@anthropic-ai/claude-agent-sdk@0.2.76` is known to work in production and does not trigger the failing `scope` behavior.
+- `0.2.116` and `0.2.119` are known to emit behavior that triggers the 400 failure.
+- Newer SDK/Claude Code behavior appears to distinguish stable/cacheable system prompt sections from dynamic sections.
+- Public evidence indicates scoped prompt caching requires `anthropic-beta: prompt-caching-scope-2026-01-05`.
+- Current injected beta headers do not include that header.
+
+## 3. Compliance Principles
+
+### 3.1 Fresh v2 first
+
+Start from upstream/fresh NanoClaw v2 behavior. Do not add LIMITLESS v1 customizations until the baseline passes SDK compliance.
+
+### 3.2 Prompt construction must be intentional
+
+The prompt must clearly separate stable/cacheable information from dynamic per-run information.
+
+Stable/cacheable content may include:
+
+- Agent identity
+- App or channel scope
+- Stable operating rules
+- Stable governance and safety constraints
+- Stable tool-use policy
+
+Dynamic/non-cacheable content must include:
+
+- User message text
+- Discord/channel metadata
+- Current task or handoff details
+- Recent conversation snippets
+- Runtime status
+- Usage-limit state
+- Request IDs
+- Timestamps
+- Secrets or credentials
+- Any one-off operational state
+
+### 3.3 No secrets in cacheable sections
+
+No token, credential, secret ID, request-specific metadata, or volatile context may appear before any SDK-recognized dynamic boundary or inside any block marked cacheable.
+
+### 3.4 Headers must match emitted request fields
+
+If the SDK emits a beta-gated request field, the final outbound request must include the beta header that authorizes that field. The relevant check is the final request to Anthropic, not merely the app’s intended header set.
+
+### 3.5 Auth route is part of compatibility
+
+The current auth route uses a Claude.ai consumer OAuth token (`sk-ant-oat01-`). Some beta features may behave differently across consumer OAuth and organization API-key (`sk-ant-api-`) routes. Switching auth should not be the first fix, but the compatibility matrix should account for it if needed.
+
+## 4. SDK Contract Checklist
+
+### 4.1 SDK version inventory
+
+For every NanoClaw v2 test run, record:
+
+- `@anthropic-ai/claude-agent-sdk` version
+- embedded Claude Code version, if present
+- `@anthropic-ai/sdk` version
+- Node/Bun runtime version
+- NanoClaw v2 commit or package version
+- OneCLI SDK/proxy version, if involved
+
+Known starting points:
+
+| SDK version | Observed result | Notes |
+| --- | --- | --- |
+| 0.2.76 | Works | Production baked image; does not trigger failing `scope` behavior |
+| 0.2.116 | Fails | Sends/causes scoped cache behavior |
+| 0.2.119 | Fails | Current v2 tested version |
+| 0.2.120 | Unknown | Exists, not proven safe |
+
+### 4.2 Prompt boundary behavior
+
+Confirm from SDK docs/source/runtime behavior:
+
+- Whether `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` is public API, internal Claude Code behavior, or both.
+- Whether host applications are expected to include the boundary explicitly.
+- Whether content before the boundary receives global/shared cache scope.
+- Whether content after the boundary avoids global scope.
+- Whether the boundary affects system prompt blocks only or also messages/tools.
+
+Checklist:
+
+- [ ] Locate authoritative SDK documentation for `SYSTEM_PROMPT_DYNAMIC_BOUNDARY`.
+- [ ] Confirm exact exported constant name/value.
+- [ ] Confirm expected placement in a host-provided system prompt.
+- [ ] Confirm whether multiple system blocks are generated.
+- [ ] Confirm which block index maps to `system.2` in the failing request.
+- [ ] Confirm whether dynamic content is currently placed before or after the boundary.
+
+### 4.3 Cache-control fields
+
+For each SDK version and prompt shape, identify whether the final request includes:
+
+- [ ] top-level `cache_control`
+- [ ] block-level `cache_control`
+- [ ] `cache_control.type`
+- [ ] `cache_control.ttl`
+- [ ] `cache_control.scope`
+
+Field-to-header mapping to verify:
+
+| Field | Stable? | Suspected/known beta header |
+| --- | --- | --- |
+| `cache_control.type = ephemeral` | Public/stable prompt caching behavior | May not require old prompt-caching beta on current API |
+| `cache_control.ttl` | Beta/extended caching behavior | `extended-cache-ttl-2025-04-11` |
+| `cache_control.scope` | Beta/scoped caching behavior | `prompt-caching-scope-2026-01-05` |
+
+### 4.4 Beta header propagation
+
+Current observed/injected header set:
+
+```text
+oauth-2025-04-20,extended-cache-ttl-2025-04-11,prompt-caching-2024-07-31
+```
+
+Candidate missing header:
+
+```text
+prompt-caching-scope-2026-01-05
+```
+
+Checklist:
+
+- [ ] Confirm app-intended beta header set.
+- [ ] Confirm OneCLI/proxy preserves all beta headers.
+- [ ] Confirm headers are merged, not overwritten.
+- [ ] Confirm OAuth beta header does not clobber scoped-caching beta header.
+- [ ] Confirm final outbound Anthropic request includes the intended full `anthropic-beta` value.
+- [ ] Confirm unsupported beta headers fail distinctly from missing beta fields.
+
+### 4.5 Auth compatibility
+
+Checklist:
+
+- [ ] Test current consumer OAuth token route with current headers.
+- [ ] Test consumer OAuth token route with `prompt-caching-scope-2026-01-05` added.
+- [ ] Only if needed, test API-key route with the same payload and headers.
+- [ ] Do not switch production auth route merely to hide the SDK mismatch.
+
+### 4.6 Streaming compatibility
+
+Because v2 streaming via OneCLI MITM has reportedly been verified, keep streaming in the matrix but do not conflate it with the scope failure.
+
+Checklist:
+
+- [ ] Minimal non-streaming request works.
+- [ ] Minimal streaming request works.
+- [ ] Real Architect prompt streaming works.
+- [ ] Error path preserves Anthropic request IDs and response body.
+- [ ] OneCLI MITM preserves `text/event-stream` behavior.
+
+## 5. Proposed Prompt Contract
+
+### 5.1 Static/cacheable section
+
+This section should be stable across sessions and safe to cache globally if the SDK chooses to do so.
+
+Recommended contents:
+
+```text
+You are the <App> Architect for LIMITLESS.
+Your stable scope is <repo/app/channel>.
+Your stable responsibilities are ...
+Your stable governance rules are ...
+Your stable tool policy is ...
+```
+
+Do not include:
+
+- Current user message
+- Recent chat history
+- Timestamps
+- Request IDs
+- Secrets
+- Runtime health/status
+- Per-task branch names unless intentionally stable
+
+### 5.2 Dynamic boundary
+
+If confirmed as host-app applicable, place the SDK boundary after the stable section and before dynamic runtime context.
+
+Conceptual form:
+
+```text
+<stable system instructions>
+
+__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__
+
+<dynamic runtime context>
+```
+
+Exact constant/value must be verified from SDK docs/source before implementation.
+
+### 5.3 Dynamic/non-cacheable section
+
+Recommended contents:
+
+```text
+Current message metadata:
+- channel
+- sender
+- timestamp
+- message ID
+
+Current user request:
+...
+
+Recent relevant context:
+...
+
+Current operational constraints:
+...
+```
+
+### 5.4 Required invariants
+
+- [ ] Dynamic content never appears before the dynamic boundary.
+- [ ] Secrets never appear in cacheable sections.
+- [ ] Stable prompt does not include stale deployment assumptions.
+- [ ] Prompt assembly is deterministic and testable.
+- [ ] Prompt blocks can be logged/snapshotted safely with secrets redacted.
+
+## 6. Compatibility Test Matrix
+
+This is a design matrix only. Execute only after explicit approval.
+
+### 6.1 Axes
+
+SDK versions:
+
+- A: `0.2.76`
+- B: `0.2.116`
+- C: `0.2.119`
+- D: latest available, e.g. `0.2.120+`
+
+Prompt shapes:
+
+- P1: minimal system prompt, no boundary
+- P2: minimal system prompt with dynamic boundary
+- P3: real Architect prompt, current shape
+- P4: real Architect prompt, refactored static/dynamic shape
+- P5: long multi-turn session prompt
+
+Header sets:
+
+- H1: current headers
+- H2: current headers + `prompt-caching-scope-2026-01-05`
+- H3: no optional prompt-caching beta headers
+- H4: SDK-default headers only
+
+Auth routes:
+
+- R1: current `sk-ant-oat01-` consumer OAuth
+- R2: `sk-ant-api-` org API key, only if needed
+
+Transport modes:
+
+- T1: direct Anthropic API, no SDK, control
+- T2: SDK direct, no OneCLI
+- T3: SDK through OneCLI MITM
+- T4: full NanoClaw v2 path
+
+### 6.2 Minimal pass/fail matrix
+
+| Test ID | SDK | Prompt | Headers | Auth | Transport | Expected purpose |
+| --- | --- | --- | --- | --- | --- | --- |
+| C-001 | none | P1 | H1 | R1 | T1 | Confirms auth/endpoint baseline |
+| C-002 | 0.2.76 | P3 | H1 | R1 | T4 | Confirms known-good old SDK path |
+| C-003 | 0.2.119 | P3 | H1 | R1 | T4 | Reproduces current failure |
+| C-004 | 0.2.119 | P3 | H2 | R1 | T4 | Tests missing scoped-cache beta hypothesis |
+| C-005 | 0.2.119 | P4 | H1 | R1 | T4 | Tests prompt refactor without new beta |
+| C-006 | 0.2.119 | P4 | H2 | R1 | T4 | Tests intended compliant v2 path |
+| C-007 | 0.2.119 | P4 | H2 | R1 | T2 | Separates SDK behavior from OneCLI proxy behavior |
+| C-008 | 0.2.119 | P4 | H2 | R2 | T2/T4 | Only if OAuth route appears incompatible |
+| C-009 | latest | P4 | H2 | R1 | T4 | Tests latest SDK after compliance fixes |
+
+### 6.3 Required capture per test
+
+For each test, capture:
+
+- SDK version
+- prompt shape identifier
+- beta header set intended by app
+- beta header set observed at final Anthropic request
+- auth route
+- response status
+- full error body if failed
+- Anthropic request ID if available
+- whether request included `cache_control.scope`
+- whether request included `cache_control.ttl`
+- whether streaming started
+- whether SSE completed
+
+## 7. Decision Gates
+
+### Gate 1: Baseline understood
+
+Pass criteria:
+
+- Current failure reproduced in a controlled test.
+- Final request payload/header mismatch identified or ruled out.
+- `system.2` block contents mapped to prompt assembly source.
+
+### Gate 2: SDK-compliant prompt contract drafted
+
+Pass criteria:
+
+- Static/dynamic prompt sections defined.
+- Boundary behavior confirmed.
+- Secrets/dynamic-state placement rules documented.
+
+### Gate 3: Header compatibility proven
+
+Pass criteria:
+
+- If `scope` is emitted, the required beta header is present at the final Anthropic request.
+- If OAuth route rejects scoped caching even with beta header, that limitation is documented.
+
+### Gate 4: Fresh v2 green baseline
+
+Pass criteria:
+
+- Real Architect prompt succeeds on fresh v2 with current or accepted SDK version.
+- Streaming works through the intended route.
+- No v1 customizations are required for baseline success except those explicitly needed for auth/transport.
+
+### Gate 5: Customization reintroduction allowed
+
+Pass criteria:
+
+- Each v1 customization has an explicit reason to be ported.
+- Each customization has a compatibility test.
+- No customization changes prompt/cache semantics unless intentionally reviewed.
+
+## 8. Recommended Work Order
+
+1. Freeze current v2 shadow state for observation.
+2. Produce source-level map of prompt construction in fresh v2.
+3. Produce source-level map of SDK cache-control behavior.
+4. Verify final outbound headers through the request path.
+5. Draft final prompt contract.
+6. Run minimal matrix C-001 through C-006 after approval.
+7. Choose whether to pin SDK temporarily or proceed with latest SDK plus compliant prompt/header handling.
+8. Only then evaluate v1 customizations.
+
+## 9. Primary Recommendation
+
+Make `NanoClaw v2 Phase 0: Anthropic Agent SDK Compliance` the mandatory first step.
+
+Short-term pinning to `@anthropic-ai/claude-agent-sdk@0.2.76` remains a safe unblock tactic, but it should not become the architectural endpoint. The durable endpoint is a fresh v2 baseline that uses the latest SDK correctly, with prompt construction and beta headers aligned to the SDK’s emitted request fields.
+
+## 10. Biggest Open Questions
+
+1. Is `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` intended for external host applications, or only internal Claude Code prompt assembly?
+2. Does `prompt-caching-scope-2026-01-05` work with the current `sk-ant-oat01-` consumer OAuth route?
+3. Is `cache_control.scope` still beta-only, or has it changed/been partially rolled back in Anthropic’s API surface?
+4. Which exact SDK version first made scoped cache control active for NanoClaw’s prompt shape?
+5. Can NanoClaw v2 disable scoped prompt caching while keeping other latest-SDK benefits?

--- a/docs/superpowers/plans/2026-04-25-v2-streaming-bug-onecli-fallback-patch.md
+++ b/docs/superpowers/plans/2026-04-25-v2-streaming-bug-onecli-fallback-patch.md
@@ -1,0 +1,282 @@
+---
+name: NanoClaw v2 — OneCLI fallback patch for streaming bug
+status: PLAN (ready for execution)
+authored-by: Director (CC session)
+incident-arc: project_2026-04-25_meridian_diff_and_streaming_bug.md
+created: 2026-04-25
+priority: P1 (unblocks shadow v2 long-running tasks; required for Phase 0 testing)
+applies-to: /home/limitless/nanoclaw-v2/src/container-runner.ts on VPS-1
+related-specs: 2026-04-25-sdk-contract-proxy-as-interop-layer.md
+---
+
+# Plan: v2 streaming-bug fallback patch — bypass OneCLI MITM via direct OAuth env
+
+## Problem
+
+OneCLI gateway 1.18.2 disconnects ~3 seconds into streaming SSE responses
+from `api.anthropic.com`. Logs show:
+
+```
+MITM method=POST /v1/messages?beta=true status=200 content_type=text/event-stream
+WARN connection error host=api.anthropic.com:443 error=serving MITM connection
+```
+
+Affects BOTH prod 1.2.53 fleet (fork code) AND shadow v2 (fresh upstream)
+because they share the same OneCLI gateway. Independent of the
+cache_control fix landed today (see
+`2026-04-25-sdk-contract-proxy-as-interop-layer.md`). Short responses
+(<3 sec) succeed; longer responses die mid-stream.
+
+This patch UNBLOCKS shadow v2 testing without waiting for OneCLI to fix
+its streaming proxy. Prod 1.2.53 stays on OneCLI for now (changing prod
+is governance-gated and not required for Phase 0).
+
+## Strategy
+
+Mirror prod 1.2.53's existing fallback pattern. Prod already supports
+direct `CLAUDE_CODE_OAUTH_TOKEN` injection when `ONECLI_URL` is unset
+(lines 385-417 of `apps/nanoclaw/src/container-runner.ts`). v2's
+`src/container-runner.ts:443` calls `onecli.applyContainerConfig`
+unconditionally. Bring v2 into shape with prod by adding the same
+`ONECLI_URL`-guarded branch.
+
+Add ONE additional refinement on top of prod's pattern: if
+`onecli.applyContainerConfig` returns `false` (configured but failed —
+e.g., agent not registered, gateway unreachable), ALSO fall back to
+direct injection. This widens the bypass surface for shadow-v2-as-test,
+which we want maximally robust.
+
+## Patch shape
+
+**File:** `/home/limitless/nanoclaw-v2/src/container-runner.ts`
+
+**Around line 437-453** (the OneCLI gateway block).
+
+### Current (problematic) code
+
+```typescript
+// OneCLI gateway — injects HTTPS_PROXY + certs so container API calls
+// are routed through the agent vault for credential injection.
+try {
+  if (agentIdentifier) {
+    await onecli.ensureAgent({ name: agentGroup.name, identifier: agentIdentifier });
+  }
+  const onecliApplied = await onecli.applyContainerConfig(args, { addHostMapping: false, agent: agentIdentifier });
+  if (onecliApplied) {
+    log.info('OneCLI gateway applied', { containerName });
+  } else {
+    log.warn('OneCLI gateway not applied — container will have no credentials', { containerName });
+  }
+} catch (err) {
+  log.warn('OneCLI gateway error — container will have no credentials', { containerName, err });
+}
+```
+
+### Proposed code
+
+```typescript
+// OneCLI gateway — injects HTTPS_PROXY + certs so container API calls
+// are routed through the agent vault for credential injection.
+//
+// Fallback ladder when OneCLI is unset, fails to apply, or throws:
+// inject CLAUDE_CODE_OAUTH_TOKEN directly via -e. Token is visible in
+// `docker inspect` on the host; acceptable for a single-operator VPS.
+// Mirrors prod 1.2.53's fallback at apps/nanoclaw/src/container-runner.ts:401.
+let onecliApplied = false;
+if (ONECLI_URL) {
+  try {
+    if (agentIdentifier) {
+      await onecli.ensureAgent({ name: agentGroup.name, identifier: agentIdentifier });
+    }
+    onecliApplied = await onecli.applyContainerConfig(args, { addHostMapping: false, agent: agentIdentifier });
+    if (onecliApplied) {
+      log.info('OneCLI gateway applied', { containerName });
+    }
+  } catch (err) {
+    log.warn('OneCLI gateway error — falling back to direct OAuth', { containerName, err });
+  }
+}
+if (!onecliApplied) {
+  if (process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    args.push('-e', `CLAUDE_CODE_OAUTH_TOKEN=${process.env.CLAUDE_CODE_OAUTH_TOKEN}`);
+    log.info('OneCLI bypassed — CLAUDE_CODE_OAUTH_TOKEN injected directly', { containerName });
+  } else {
+    log.warn('No OneCLI and no CLAUDE_CODE_OAUTH_TOKEN — container will have no Anthropic credentials', { containerName });
+  }
+}
+```
+
+**Net delta:** ~12 added lines, ~2 removed lines. Effective net ~10 lines
+of new code. (Earlier "5 line" estimate from the topic file was
+optimistic — accurate count after looking at the actual surrounding
+code is ~10.)
+
+## Behavior matrix after patch
+
+| `ONECLI_URL` set? | OneCLI applies? | `CLAUDE_CODE_OAUTH_TOKEN` set? | Outcome |
+|---|---|---|---|
+| Yes | Yes | irrelevant | OneCLI mode (current behavior, unchanged) |
+| Yes | No (returned false / threw) | Yes | Direct OAuth injection (NEW) |
+| Yes | No | No | Warning, no creds (degraded — same as today) |
+| No | n/a | Yes | Direct OAuth injection (NEW) |
+| No | n/a | No | Warning, no creds (degraded — same as today) |
+
+The first row is the only one operators will see in normal operation
+once this patch lands AND OneCLI's streaming bug is fixed upstream. The
+second + fourth rows are the bypass paths for shadow v2.
+
+## Activating bypass mode for shadow v2
+
+Two operator switches activate the bypass path:
+
+**Option A (preferred for testing) — unset `ONECLI_URL` in shadow v2 env:**
+
+```bash
+# On VPS-1, edit /home/limitless/nanoclaw-v2/.env
+# Comment out: ONECLI_URL=https://...
+# Add: CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+# Restart shadow v2
+```
+
+This gives a clean experiment: shadow v2 talks directly to Anthropic;
+prod's OneCLI is untouched.
+
+**Option B (less invasive) — keep `ONECLI_URL` set, accept the fallback
+when OneCLI fails:**
+
+After the patch lands, OneCLI's existing 3-sec streaming death will
+trigger an async error mid-request. The fallback only fires for NEW
+container spawns, not in-flight requests, so this option doesn't fully
+fix streaming for shadow v2. **Don't pick Option B for streaming tests
+— pick Option A.**
+
+## Verification approach
+
+### Pre-merge (local / dev container)
+
+1. Build the patched container-runner: `pnpm run build` in
+   `/home/limitless/nanoclaw-v2/`
+2. Run `pnpm run typecheck` — must pass
+3. Verify no other call sites assume OneCLI always applies (search:
+   `grep -n "onecliApplied" src/`)
+
+### Post-merge functional test on shadow v2
+
+Set up Option A (unset `ONECLI_URL`, set `CLAUDE_CODE_OAUTH_TOKEN`).
+Restart shadow v2. Run three increasingly long tests:
+
+| Test | Prompt | Expected outcome (post-fix) |
+|---|---|---|
+| Short | "what's 2+2?" | ~3 sec response, completes (already works on shadow v2 today) |
+| Medium | "explain Anthropic prompt caching" | ~10-15 sec response, completes (FAILS today due to streaming death) |
+| Long | "write 3-paragraph technical brief on SDK contract enforcement" | ~30 sec response, completes (FAILS today) |
+| Tool use | "read package.json and summarize" | Tool call + response, completes |
+| Multi-turn | 3-message conversation with context | All three turns complete |
+
+Definition of done: All 5 tests succeed. Container exits with code 0
+(not 137).
+
+### Post-merge regression check on prod 1.2.53
+
+The patch lives only in v2's repo path
+(`/home/limitless/nanoclaw-v2/`), so prod 1.2.53 fork is unaffected by
+default. Sanity check after deploy:
+
+- Prod NanoClaw service still active: `systemctl status nanoclaw`
+- Spawn a fresh Architect via the standard Discord dispatch path
+- Confirm the Architect container shows `OneCLI gateway applied` in
+  logs (not the new `OneCLI bypassed` message — prod stays on OneCLI)
+
+### Test environment (when env-pipeline lands)
+
+This patch should also land in Test environment as part of the
+multi-env pipeline rollout (see
+`2026-04-25-multi-environment-architect-pipeline.md`). Test env will
+exercise the full path automatically on each Architect dispatch and
+catch any future regressions.
+
+## PR shape
+
+**Branch:** `fix/v2-onecli-fallback-streaming-bypass`
+
+**Title:** `fix(nanoclaw-v2): direct OAuth fallback when OneCLI unset or fails`
+
+**Description outline:**
+
+```
+## Problem
+OneCLI 1.18.2 has a streaming-disconnect bug at ~3 sec on SSE responses
+from api.anthropic.com. Affects shadow v2 testing.
+
+## Fix
+Mirror prod 1.2.53's existing fallback pattern in v2's
+container-runner.ts: when ONECLI_URL is unset OR onecli.applyContainerConfig
+returns false / throws, inject CLAUDE_CODE_OAUTH_TOKEN directly to
+container env via -e.
+
+## Scope
+- v2 only. Prod 1.2.53 fork already has this fallback (lines 401-417 of
+  apps/nanoclaw/src/container-runner.ts).
+- Bypass mode is opt-in: set CLAUDE_CODE_OAUTH_TOKEN + unset ONECLI_URL.
+- Default behavior with ONECLI_URL set: unchanged (still uses OneCLI).
+
+## Verification
+- 5-test functional matrix on shadow v2 (short, medium, long, tool use,
+  multi-turn) — all must complete without code 137 / streaming death.
+- Prod 1.2.53 sanity check — Architect spawn still uses OneCLI mode.
+
+## Related
+- Spec: 2026-04-25-sdk-contract-proxy-as-interop-layer.md
+- Incident: project_2026-04-25_meridian_diff_and_streaming_bug.md
+- Phase 0: 2026-04-25-nanoclaw-v2-phase-0-sdk-compliance-handoff.md
+
+## §5.5 attestation
+Manual verification of the 5-test functional matrix on shadow v2 with
+CLAUDE_CODE_OAUTH_TOKEN injected and ONECLI_URL unset. CLI socket at
+/home/limitless/nanoclaw-v2/data/cli.sock. Test commands: `pnpm run
+chat 'message'`. Container exit codes captured.
+```
+
+## Risks + mitigation
+
+| Risk | Mitigation |
+|---|---|
+| Token visible in `docker inspect` host-side | Acceptable on VPS-1 (single-operator); documented in fallback log line. Out of scope for this patch — the token-via-env trade-off is explicitly accepted by prod 1.2.53 already. |
+| Operator forgets to set `CLAUDE_CODE_OAUTH_TOKEN` and shadow v2 silently has no creds | The new warning log message is explicit. Phase 0 functional test catches this on first dispatch. |
+| Shadow v2 runs both modes simultaneously (OneCLI + direct env) | Code is mutually exclusive: direct injection only fires when OneCLI didn't apply. Tested via behavior matrix above. |
+| OneCLI streaming bug gets fixed upstream and we forget to re-enable OneCLI mode for shadow v2 | Re-enabling = setting `ONECLI_URL` back. Document in shadow v2 README + tag in handoff for next-session checklist. |
+| Patch doesn't address the streaming bug for prod | Out of scope. Prod has a separate OneCLI streaming-death issue but only on long requests, and prod doesn't run long requests through Architect proactive checks (those are <3 sec each). Long-form Architect dispatches today are the missing capability — this patch restores it for shadow v2 only. |
+
+## Out of scope
+
+- Fixing OneCLI's streaming proxy itself. That's an OneCLI-source-code
+  investigation in Rust at `https://github.com/onecli/onecli/apps/gateway`.
+  Open-ended; deferred until the SDK Compliance Phase 0 deliverables
+  prove shadow v2 actually does what we need without OneCLI.
+- Changing prod 1.2.53 to bypass OneCLI. Prod's fork has its own fallback
+  but defaults to OneCLI mode for credential vault auditability. Not
+  changing that without separate governance review.
+- Adding `ANTHROPIC_API_KEY` as a third fallback credential type. The
+  consumer OAuth (`sk-ant-oat01-`) is what's in use; API-key swap is a
+  Phase 1+ decision (per Phase 0 SDK Compliance handoff §"Anthropic
+  credentials").
+
+## Definition of done
+
+- [ ] Patch applied to v2 `src/container-runner.ts` on a feature branch
+- [ ] `pnpm run build` clean, `pnpm run typecheck` clean
+- [ ] 5-test functional matrix passes on shadow v2 with bypass mode
+- [ ] Prod 1.2.53 sanity check: Architect spawn still logs OneCLI applied
+- [ ] PR opened, §5.5 attestation in body, formal Approving Review per
+      ruleset 15502000, squash-merge
+- [ ] Shadow v2 README updated with bypass mode operator notes
+- [ ] Topic file `project_2026-04-25_meridian_diff_and_streaming_bug.md`
+      updated to mark "streaming bug fix" as RESOLVED for shadow v2
+
+## Suggested executor
+
+Infra Architect (intimate codebase knowledge, owner of v2 install on
+VPS-1). Dispatch via #infra-eng once Architect fleet is operational
+under Phase 0 SDK compliance — until then, this patch can be hand-applied
+by Director with CEO ratification, since the change is small and
+surgical and the verification matrix is explicit.

--- a/docs/superpowers/proposals/2026-04-25-cache-control-scope-investigation-handoff.md
+++ b/docs/superpowers/proposals/2026-04-25-cache-control-scope-investigation-handoff.md
@@ -1,0 +1,188 @@
+---
+status: OPEN — awaiting analysis
+type: research-only handoff (NO ACTIONS)
+intended-recipients: any Architect with research capability — OpenClaw Director (re-enabled with gpt-5.5), CEO's external Architect (parallel experiment), or future NanoClaw Architect once fleet is restored
+created: 2026-04-25
+priority: P1 (blocks shadow v2 architect from being usable today)
+constraints: ANALYSIS ONLY. Do NOT modify code, config, secrets, deployments, or anything else. Do NOT direct other agents. Do NOT take or recommend irreversible actions. Output is text-only — Discord reply or markdown summary returned to Director.
+---
+
+# Investigation: `cache_control.ephemeral.scope` rejection by Anthropic API
+
+## TL;DR
+
+We're trying to run a "shadow" instance of NanoClaw v2 (`/home/limitless/nanoclaw-v2/` on VPS-1, registered as a CLI agent in the existing OneCLI vault) so we have a working Architect for analysis tasks while our prod NanoClaw 1.2.53 fleet is partially broken. Everything works EXCEPT: every chat request returns `400` from Anthropic with:
+
+```
+{"type":"error","error":{"type":"invalid_request_error","message":"system.2.cache_control.ephemeral.scope: Extra inputs are not permitted"}}
+```
+
+The `scope` field is being sent inside `cache_control.ephemeral` by `@anthropic-ai/claude-agent-sdk` versions ≥ 0.2.116 (and confirmed in 0.2.119, the current latest). Our PROD's older 0.2.76 doesn't send it. Anthropic's API rejects the field with strict-schema validation.
+
+We need to understand: **why is the `scope` field being rejected, what configuration would make it accepted, and what's the right path forward?**
+
+## Full context
+
+### What we observe
+
+Every Anthropic `/v1/messages?beta=true` request from our v2 shadow agent dies with the 400 above. OneCLI gateway logs confirm the request makes it to Anthropic intact, claude-agent-sdk retries internally and may eventually succeed (we've seen `200` with `text/event-stream` content type follow the 400 within 600ms in some traces), but the agent-runner surfaces the first 400 as the user-visible error and the chat client exits with `"API Error: 400 ..."`.
+
+Sample Anthropic request_ids hitting this: `req_011CaPzpsjGkQoybmaTLLfEy`, `req_011CaQ1AqRRSi8pQFtKnBSZw`, `req_011CaQ1KJMeBixapvvNK3fKH`, `req_011CaQ1hh4FQeY11Ga38eFgo`.
+
+### Decoding the error
+
+| Path component | Meaning |
+|---|---|
+| `system` | `system` field of the request body (array of system content blocks) |
+| `.2` | Index 2 — the third system block (0-indexed) |
+| `.cache_control` | That block has a `cache_control` object |
+| `.ephemeral` | The cache_control type is `ephemeral` |
+| `.scope` | That ephemeral object has a sub-field called `scope` |
+| `Extra inputs are not permitted` | Strict-schema rejection of unknown field |
+
+So claude-agent-sdk is constructing a system message array where the third entry has `cache_control: { type: "ephemeral", scope: <something> }`. Anthropic's API doesn't accept the `scope` field.
+
+### What works vs what doesn't
+
+| Configuration | claude-agent-sdk version | Result |
+|---|---|---|
+| Prod 1.2.53 fleet (older image baked 2026-04-03) | **0.2.76** | Works — Anthropic returns 200 |
+| Shadow v2 (image built 2026-04-25, claude-code 2.1.119 pinned) | **0.2.116** | Hits the 400 |
+| Shadow v2 after upgrading agent-runner package.json to `0.2.119` + rebuild | **0.2.119** | Still hits the 400 |
+| Direct curl to `/v1/messages` (no `?beta=true`) with Bearer + anthropic-beta header (no `cache_control` at all) | n/a — no SDK | Works — Anthropic returns 200 |
+| Direct curl to `/v1/messages?beta=true` with Bearer + anthropic-beta header (no cache_control) | n/a — no SDK | Works — Anthropic returns 200 |
+
+So the pattern: **the `scope` field was introduced in claude-agent-sdk between 0.2.76 and 0.2.116; it triggers Anthropic 400 even when the request is otherwise valid.**
+
+### Beta headers we currently inject (via OneCLI's "Anthropic Beta Header" generic secret)
+
+`anthropic-beta: oauth-2025-04-20,extended-cache-ttl-2025-04-11,prompt-caching-2024-07-31`
+
+We've tried adding `extended-cache-ttl-2025-04-11` and `prompt-caching-2024-07-31` — the 400 persists. Maybe we need a different beta header to enable `scope`, or `scope` is account-feature-gated and not exposed via beta header.
+
+### Auth context
+
+- We use Anthropic OAuth token: `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` (truncated obviously — full token is in OneCLI's anthropic-type secret on VPS-1)
+- Token is from a Claude.ai subscription (Claude Max, originally), not an org-level API key (`sk-ant-api-...`)
+- This may matter: account/plan-feature-gating is plausible
+
+### v2 architecture details that might be relevant
+
+- v2 runs claude-agent-sdk in **Bun** runtime (not Node) inside the agent-runner container. Bun's HTTP client may serialize requests slightly differently than Node, but unlikely to add a `scope` field on its own.
+- v2 uses **two-DB session split** (`inbound.db` host-write / `outbound.db` container-write). The system message construction happens inside the container (claude-agent-sdk side), not on the host.
+- v2's container Dockerfile pins `CLAUDE_CODE_VERSION=2.1.116` originally — we bumped to `2.1.119`. The CLI is installed via `pnpm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}` and bundles its own `claude-agent-sdk`, but the AGENT-RUNNER side (which is what does the actual API calls) installs its own `@anthropic-ai/claude-agent-sdk` via Bun in `/app/node_modules/`.
+- Per `/home/limitless/nanoclaw-v2/container/agent-runner/package.json`: `"@anthropic-ai/claude-agent-sdk": "^0.2.116"` — **caret-pinned**, so it picked 0.2.116. We've since bumped to `0.2.119` directly.
+
+### What "everyone else's v2 works" likely means
+
+NanoClaw v2 shipped 2026-04-22 and is in active use. CEO's empirical observation: many users have it running successfully. Plausible explanations for why ours doesn't:
+
+1. **Account-feature gating.** Anthropic may have ENABLED the `scope` field for some accounts (specifically: API-key accounts on Claude Console org plans, or accounts enrolled in a beta program) but NOT for ours. Our `sk-ant-oat01-` token is a Claude.ai consumer subscription — feature support may differ from `sk-ant-api-` org keys.
+2. **Required beta header we don't know.** Anthropic gates new fields behind specific `anthropic-beta` header values. We inject `oauth-2025-04-20,extended-cache-ttl-2025-04-11,prompt-caching-2024-07-31`. The `scope` field may need a different beta name.
+3. **Recent server-side regression on Anthropic's side.** Anthropic may have intended to support `scope` but pushed a server change that broke it. Other v2 users may also be hitting this RIGHT NOW (today) — community channels may show it.
+4. **SDK config option to disable.** The agent-runner-src might have a parameter passed to `query()` that controls cache_control attachment. Our v2 install hasn't customized this. Default behavior includes `scope`.
+5. **Most v2 community users are on API keys, not OAuth subscriptions.** OAuth was historically claude.ai-only; API access historically required `sk-ant-api-`. Our OAuth-on-API-endpoint usage may be relatively rare in the v2 community.
+
+## Specific research questions for the Architect
+
+Please investigate and report back. **Do not act — just research and recommend.**
+
+### Q1 — `scope` field provenance
+
+When was the `scope` field added to `@anthropic-ai/claude-agent-sdk`'s cache_control construction? Bisect (or look at the SDK changelog / release notes / git history if accessible) between 0.2.76 (works) and 0.2.116 (broken). Identify:
+
+- Earliest SDK version that sends `scope`
+- Latest SDK version that does NOT send `scope`
+- Any release-note context about why `scope` was added (linked Anthropic feature, beta program, etc.)
+
+### Q2 — Anthropic API status of `scope`
+
+Search Anthropic's:
+- Public API documentation (https://docs.anthropic.com/api/prompt-caching and adjacent)
+- Beta-features documentation
+- Release notes / API changelog
+- Discord / community
+
+Determine:
+- Is `cache_control.ephemeral.scope` a documented field?
+- If yes, what beta header (or account configuration) enables it?
+- If no, is there evidence it was REMOVED from the API recently? (If so, when?)
+- Any equivalent / replacement field (e.g., `ttl` instead of `scope`)?
+
+### Q3 — Other v2 users hitting the same error
+
+Search:
+- NanoClaw upstream Discord / Issues (https://github.com/qwibitai/nanoclaw + https://discord.gg/VDdww8qS42)
+- claude-agent-sdk Issues (https://github.com/anthropics/claude-agent-sdk presumably; search for it)
+- Anthropic support forums
+
+Determine:
+- Has this 400 been reported by other v2 users in the last 1-2 days?
+- Any documented workaround (SDK version pin, beta header, env var, config)?
+
+### Q4 — Recommendation
+
+Based on Q1-Q3 findings, what should we do?
+
+Candidate paths:
+- (a) Pin claude-agent-sdk in v2's agent-runner to a specific older version (e.g., 0.2.95 or wherever scope was introduced − 1)
+- (b) Configure agent-runner to disable prompt caching entirely (if SDK option exists)
+- (c) Add a different beta header to OneCLI injection (specific value to be identified by Q2)
+- (d) Switch to API key auth (`sk-ant-api-`) instead of OAuth — if account-gating is the issue
+- (e) Wait for Anthropic / SDK to align — if it's a transient bug being fixed upstream
+- (f) Some other approach we haven't considered
+
+Recommend ONE primary path with rationale, plus a fallback if primary fails.
+
+## Constraints — STRICT
+
+This task is **analysis only**. The Architect must:
+
+- ❌ NOT modify any source code
+- ❌ NOT modify any config (OneCLI secrets, env vars, Dockerfiles, package.json)
+- ❌ NOT execute any deploys, restarts, builds, or installations
+- ❌ NOT instruct or direct other agents (no IPC, no Discord cross-channel directives)
+- ❌ NOT post any GitHub PRs, issues, comments, or other persistent artifacts
+- ❌ NOT push, pull, or otherwise modify the monorepo
+- ❌ NOT execute any irreversible action
+
+The Architect MAY:
+
+- ✅ Read public web resources (Anthropic docs, GitHub repos, npm registry, community forums)
+- ✅ Read local files (this handoff, our git history, our package.json, our SDK install state)
+- ✅ Run read-only inspection commands (`docker run ... --entrypoint cat ...`, `git log`, `npm view`, etc.)
+- ✅ Reason about findings
+- ✅ Output a recommendation back to Director (text or markdown)
+
+The motivation for this constraint: in a prior incident (2026-04-22) the OpenClaw Director issued unauthorized directives that triggered an Architect to push an irreversible code change. Per `feedback_governance_determinism_primacy.md` and the bot-feedback-loop incident report (PR #82), all Director-level bot agents are restricted to analysis-only tasks until DR-003 governance ratifies bot directive authority. This task respects that constraint.
+
+## Output format
+
+Deliver a Discord reply (300-1500 words) OR a markdown summary, addressed back to Director, containing:
+
+1. **Summary** — 1-2 sentences answering "what's the root cause + the fix"
+2. **Q1 findings** — SDK version where `scope` was introduced + supporting evidence
+3. **Q2 findings** — Anthropic API status of `scope` + beta header (if any) that enables it
+4. **Q3 findings** — community signal (others hitting it / not / what they did)
+5. **Q4 recommendation** — primary path + rationale + fallback
+6. **Confidence** — your subjective confidence in the recommendation (low/medium/high) and the biggest uncertainty
+
+Do NOT post the recommendation directly into prod systems. Do NOT begin executing the recommendation. The recommendation goes to Director, who surfaces to CEO, who decides whether to execute.
+
+## References / artifacts available
+
+- This handoff: `docs/superpowers/proposals/2026-04-25-cache-control-scope-investigation-handoff.md`
+- Shadow v2 install: `/home/limitless/nanoclaw-v2/` on VPS-1 (currently running, service log at `/home/limitless/nanoclaw-v2/data/service.log`)
+- Shadow v2 image: `nanoclaw-agent-v2-e89339a5:latest` (built 2026-04-25, claude-code 2.1.119, claude-agent-sdk 0.2.119)
+- OneCLI on VPS-1: gateway 1.18.2 (image dated 2026-04-22), CLI 1.4.1
+- OneCLI secrets on VPS-1:
+  - `Anthropic` (id: 18646778-e05f-4825-a615-e88893428338) — type=anthropic — auto-injects Bearer auth
+  - `Anthropic Beta Header` (id: 84bc6286-52b1-4053-b5fa-0f50826ad5c4) — type=generic — injects `anthropic-beta: oauth-2025-04-20,extended-cache-ttl-2025-04-11,prompt-caching-2024-07-31`
+- Prod fleet image: `nanoclaw-agent:latest` (claude-code 2.1.119, claude-agent-sdk 0.2.76 — older bundled SDK)
+- Prod 1.2.53 vs upstream 2.0.13 architecture diff: `docs/superpowers/proposals/2026-04-25-multi-environment-architect-pipeline.md` (env-pipeline doc references the v2 migration scope)
+- Anthropic API endpoint: `https://api.anthropic.com/v1/messages?beta=true`
+- claude-agent-sdk on npm: `https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk`
+
+## Caveat for any Architect picking this up
+
+The Director (the human-LLM hybrid running this from the CEO's Claude Code session) has spent ~2 hours bisecting today and reached the conclusions above. The next 30-60 minutes of investigation by the Architect should produce a confident recommendation. If after that time the Architect is also stuck, surface a "still investigating" status update with what you've ruled out, so Director can re-route or escalate.

--- a/docs/superpowers/proposals/2026-04-25-multi-environment-architect-pipeline.md
+++ b/docs/superpowers/proposals/2026-04-25-multi-environment-architect-pipeline.md
@@ -1,0 +1,166 @@
+---
+status: DRAFT
+author: Director (drafted on behalf of CEO insight 2026-04-25)
+intended-reviewer: Infra Architect (primary) + main-ops Architect (cross-cutting governance review)
+created: 2026-04-25
+priority: P0 (strategic — gates safe execution of v2 migration and all future structural changes)
+---
+
+# Multi-Environment Architect Pipeline (Dev → Test → Staging → Prod)
+
+## Origin
+
+CEO insight, 2026-04-25, immediately after the ~10-hour fleet-breakage incident triggered by the Week 1 Node 24 deploy:
+
+> "We should've had a structured pipeline (Dev → Test → Staging → Prod) to ensure stability. The Architects are themselves a development project and we were in the process of migrating the very agentic AI dev team into a de-facto dev project (just like codex+omx+clawhip are a dev project living on github), we should've thought about setting corresponding environments before doing these changes."
+
+This proposal codifies that insight into a formal environment model + setup plan.
+
+## The structural bug we're fixing
+
+The agentic AI Architect fleet **is itself a software product** — built from NanoClaw + custom container-runner code + per-Architect CLAUDE.md fragments + OneCLI integration + GitHub App identity layer + Discord-bound channels. It's actively under development, with a steady cadence of upstream syncs, custom features, and dependency upgrades. It deserves the same engineering discipline as any other software product in the org.
+
+Until now, that product has been treated as production-only infrastructure. There has been one running NanoClaw fleet (VPS-1), and every change has gone directly to it. This is the structural bug.
+
+The asymmetry is jarring once named:
+- **Codex/OMX/Clawhip integration**: treated as a project — proper repos, branches, environments (dev → CI → staging → prod), governance, peer review.
+- **Architects themselves (the team that does the integration work)**: treated as production-only infrastructure — every change to them is a direct prod change.
+
+## Why this matters: every class of incident today maps to a missing environment
+
+| Today's failure | Caught at | How |
+|---|---|---|
+| Week 1 Node 24 deploy activated dormant OneCLI-proxy code path (multi-PR cascade compiled at once into dist/index.js) | **Test** | Full container lifecycle exercised against Test OneCLI; failure visible before touching prod |
+| OneCLI version drift (1.1.0 → 1.4.1, 3 majors stale) | **Dev → Test** | Periodic upgrade rehearsals as part of dependency-freshness checks |
+| Missing `ONECLI_API_KEY` env var (latent for entire deployment lifetime) | **Dev** | First proper `/init-onecli` skill execution would have populated it; Test would re-validate from scratch each rehearsal |
+| Anthropic OAuth handling change requiring `anthropic-beta: oauth-2025-04-20` header | **Staging** | E2E smoke test against real Anthropic in Staging detects external-dependency contract drift |
+| OneCLI MITM streaming bug on long requests | **Test/Staging** | First long-output Architect dispatch (any non-trivial doc) exercises this; surfaces well before reaching CEO |
+| 11 minutes of Architect work lost to ephemeral container idle-timeout | **Dev** | Iterative dev loop has no idle-timeout-cull because dev sessions are interactive |
+| Code 137 silent failures every 4 hours on proactive checks (not surfaced for ~8 hours) | **Test/Staging** | Smoke-test-on-deploy + alerting on prod failure rate would have surfaced within minutes |
+
+**Every incident class today maps to a missing environment.** This is not coincidence. Single-environment systems concentrate all failure modes onto live users.
+
+## Proposed environment model
+
+| Env | Where | Discord namespace | Purpose | Promotion gate |
+|---|---|---|---|---|
+| **Dev** | Local CEO laptop or dedicated dev-VPS | DM-only or no live channels | Write & iterate code, test individual containers, exercise dependency upgrades, validate config changes | Self-test by author |
+| **Test** | Separate Hetzner CX32 VPS (call it VPS-3 or `nanoclaw-test`) | Separate Discord guild OR `#test-*-eng` channels under a separate test bot | Integration tests, version rehearsals, dormant-code-path activation, full container lifecycle, dependency-freshness checks, "rebuild from scratch" rehearsals | Automated test suite + Director smoke-test |
+| **Staging** | Mirror of VPS-1 architecturally (same versions, same config shape, separate VPS — call it VPS-4 or `nanoclaw-staging`) | Separate staging Discord guild + staging bot identity OR `#staging-*-eng` channels | Pre-prod validation with prod-like data shapes; manual CEO acceptance | CEO ratification |
+| **Prod** | VPS-1 (current state — `nanoclaw-prod`) | Live LIMITLESS Architect bot in real channels | Real CEO-facing work | Strict — only what passed all earlier envs |
+
+### Environment isolation requirements
+
+Each env needs its OWN:
+- **VPS** (or at minimum: separate Docker namespace + ports if shared host — strongly prefer separate VPS for true isolation)
+- **NanoClaw service** (systemd unit + clone of monorepo + dist build)
+- **OneCLI gateway + DB** (separate docker-compose + secrets)
+- **Discord bot identity + guild allowlist** (separate bot tokens; separate guild for true isolation, OR namespaced channels in shared guild)
+- **GitHub App** (separate `limitless-agent-test` and `limitless-agent-staging` Apps — or scoped install to test/staging repos only)
+- **Anthropic credentials** (ideally separate OAuth/API key per env so usage is attributable + capped)
+
+### Promotion-pipeline mechanics
+
+**Code path (per change):**
+1. Dev → Test: `git push` to a `dev` branch; CI deploys to Test VPS automatically
+2. Test → Staging: PR merge to `staging` branch; CI deploys to Staging VPS
+3. Staging → Prod: PR merge to `main`; CI deploys to Prod VPS (this is current DR-002 Phase 3 pipeline, scope expanded)
+
+**Promotion gates (each is blocking):**
+- Dev → Test: author confirms local container spawns + completes a smoke task
+- Test → Staging: automated test suite passes (container lifecycle, OneCLI integration, App token mint, Discord roundtrip, simple Architect dispatch)
+- Staging → Prod: CEO acceptance + (eventually, when team grows) human peer-review
+
+**Dependency upgrades follow the same path:** any version bump (Node, claude-code, OneCLI, base image, npm dep) ships through Dev → Test → Staging → Prod with the same gates.
+
+## Cost estimate (rough, monthly steady-state)
+
+| Item | Cost |
+|---|---|
+| Hetzner CX32 × 2 (test + staging; prod = current VPS-1) | ~60€/month |
+| OneCLI gateway × 2 (postgres + app containers — runs on the same Hetzner boxes) | $0 (self-hosted on same VPS) |
+| Test/Staging Discord bots | $0 (Discord bots are free) |
+| Test/Staging GitHub Apps | $0 (free) |
+| Anthropic credentials for test/staging (separate OAuth tokens or a metered API key with usage cap) | $0–$50/month (depends on test volume; capped) |
+| **Total operational** | **~60–110€/month** |
+
+One-time setup labor: 3–5 Architect-days (estimated).
+
+## Setup labor breakdown
+
+1. **Terraform module** for "create a NanoClaw env" — parameterized by env name, generates Hetzner VPS + DNS + initial firewall (~1 day)
+2. **Ansible playbook** for first-run on a new env — installs Docker, OneCLI, NanoClaw service, Node, pnpm, deps; idempotent re-runnable (~1.5 days)
+3. **Env-segregation of secrets/credentials** — separate `secrets.env` per env, separate App private keys, separate Discord tokens (~0.5 day)
+4. **Promotion-pipeline scripts (or manual promotion checklist)** — initially manual, scripts as automation matures (~1 day)
+5. **Test suite** — automated tests that exercise the full Architect lifecycle in Test env (container spawn + Claude query roundtrip + App token mint + Discord post + idle-timeout behavior) (~1 day)
+
+## Critical implementation questions (for Architect refinement)
+
+1. **Dev env: laptop vs dedicated dev-VPS?** Laptop is cheap but Apple-Container restrictions / OS differences may diverge from prod. Dedicated dev-VPS is easier to keep parity. Cost vs friction tradeoff.
+
+2. **Test/Staging Discord: separate guild or namespaced channels?** Separate guild = full isolation, costs nothing. Namespaced channels = faster setup, but accidents could leak between envs. Recommend separate guild.
+
+3. **GitHub App for test/staging: separate App or scoped install?**
+   - Separate App: cleaner attribution (`limitless-agent-test[bot]`, `limitless-agent-staging[bot]`)
+   - Same App, scoped to test/staging repos: simpler key management
+   - Recommend separate Apps for cleanest audit boundary; minor key management overhead is acceptable.
+
+4. **Anthropic credentials: how to avoid double-billing?** Each env needs its own account/credential or test+staging share a metered API key with usage caps. CEO call.
+
+5. **DR-001 Phase 3 (App token minting): does it need a per-env App registration?** Almost certainly yes — `limitless-agent-test[bot]` for test repo PRs, etc. Maps to question 3.
+
+6. **Renovate / dependency updates: per-env or shared?** If Renovate auto-PRs go to Dev branch, they flow Dev → Test → Staging → Prod naturally. Shared.
+
+7. **Test data — synthetic or production-shape?** Test should use synthetic (faster, no risk). Staging should use prod-shape data (real channels, real PRs in a staging repo).
+
+8. **Backup / rollback per env?** Prod has the existing `/home/limitless/nanoclaw.backup-*` pattern. Test/Staging probably don't need backups (they're disposable / re-buildable from Terraform).
+
+## Why this is P0
+
+1. **The v2 migration is the highest-risk change in NanoClaw's history for our fork.** Doing v2 migration in prod-only is a guaranteed re-run of today's incident at much larger scale (10x the moving parts).
+
+2. **Every future structural change** (Bun runtime adoption, new channel additions, OneCLI app additions) deserves the same staging discipline. Building the pipeline once and reusing it forever has compounding ROI.
+
+3. **The agentic-team-as-dev-project framing aligns with how we already treat other dev work.** This closes a structural gap, not adds new infrastructure for its own sake.
+
+4. **Today's recovery cost was ~10 hours of CEO + Director focus.** A single avoided incident pays for the setup labor.
+
+## Sequencing recommendation
+
+1. **First:** Architect refines this proposal into a formal spec (when fleet is back). CEO ratifies.
+2. **Then:** Architect (or Director if Architects still down) executes Terraform + Ansible setup. Test + Staging envs come online.
+3. **Then:** v2 migration executes Dev → Test → Staging → Prod through the new pipeline.
+4. **Going forward:** all dependency upgrades, governance changes, NanoClaw upstream syncs follow the same Dev → Test → Staging → Prod path.
+
+## Open questions for CEO (before/during ratification)
+
+- Cost cap acceptable? (~60–110€/month operational + 3–5 days labor)
+- Q3 (separate App vs scoped): preference?
+- Q4 (Anthropic billing): preference?
+- Should this be one more spec under DR-NNN governance, or a standalone `docs/governance/architect-pipeline.md` policy doc?
+- Timeline: does this need to land BEFORE v2 migration, or can v2 migration be the FIRST thing the new pipeline tests (riskier but faster)?
+
+## Related memories / DRs (for Architect when refining)
+
+- `feedback_verification_first.md` (incl. amendment 2026-04-24 on E2E capability smoke test) — pipeline is the platform-level enforcement of this principle
+- `feedback_persistent_storage_for_work_products.md` — env discipline includes preserving WIP across env-rebuilds
+- `feedback_blocker_surface_latency.md` — Test env should expose blockers within their cull-window
+- `feedback_prefer_rigor_over_speed.md` — pipeline IS rigor over speed, codified
+- `feedback_canonical_docs_first.md` (TBD — drafting from today's fleet incident) — Test env exercises canonical setup paths (`/init-onecli` etc.) so missing config surfaces deterministically
+- DR-002 — monorepo-as-source-of-truth + GitHub Actions deploy pipeline (Phase 3 still pending). Pipeline should expand from "deploy to prod on merge" to "deploy through Dev/Test/Staging/Prod stages on respective merges"
+- `project_agentic_governance.md` — existing governance arc; pipeline becomes a §X amendment
+
+## Architect tasks queued (when fleet operational)
+
+- [ ] Refine + ratify this proposal as a formal spec under `docs/superpowers/specs/`
+- [ ] Author Terraform module for "create a NanoClaw env"
+- [ ] Author Ansible playbook for first-run setup
+- [ ] Author env segregation for secrets/credentials (per-env `secrets.env`, per-env GitHub App private keys, per-env Discord tokens)
+- [ ] Author promotion-pipeline scripts (or initially: manual promotion checklist)
+- [ ] Author automated test suite for Test env validation
+- [ ] Update DR-002 Phase 3 deploy pipeline scope to handle multi-env promotion
+- [ ] Document per-env runbooks (deploy, debug, rollback)
+
+---
+
+*This proposal is Director-drafted on behalf of CEO insight. Marked DRAFT pending Architect refinement once the streaming bug / fleet operational state is restored. Any Director-drafted assumptions should be flagged + corrected by the reviewing Architect — Architect has authority to restructure entirely.*

--- a/docs/superpowers/proposals/2026-04-25-nanoclaw-v2-phase-0-sdk-compliance-handoff.md
+++ b/docs/superpowers/proposals/2026-04-25-nanoclaw-v2-phase-0-sdk-compliance-handoff.md
@@ -1,0 +1,180 @@
+---
+status: OPEN — awaiting execution
+intended-recipient: NanoClaw Infra Architect (fleet bot — has intimate codebase + infra knowledge)
+authorization: CEO (2026-04-25, in #main-ops dialogue with OpenClaw Director gpt-5.5 + Director)
+created: 2026-04-25
+priority: P1 (gates v2 migration; gates Architect fleet recovery)
+authority: ACTIONS ALLOWED (this is execution-grade, not analysis-only). Follows normal governance: PR + CEO ratification per phase.
+---
+
+# NanoClaw v2 Phase 0 — SDK Compliance & Clean-Room Bootstrap
+
+## CEO framing (verbatim, 2026-04-25T07:54Z)
+
+> "this is actually an opportunity for us to do things properly with a fresh nanoclaw v2 version which does not yet have our customizations. After we have it up and running properly we can cherry pick what customizations to introduce from our older v1 version. It seems obvious that the first place to start will be a comprehensive analysis of the new SDK requirements so we are in compliance and can get our nanoclaw v2 fully operational before adding customization."
+
+This handoff codifies that framing into an executable plan. **Phase 0 = SDK compliance first; v1 customization port is later, gated, and selective.**
+
+## Background — what's broken today
+
+We've spent ~24 hours of CEO+Director time discovering:
+
+1. **Prod 1.2.53 fleet** is partially working (short tasks succeed, long-streaming tasks die at code 137 ~7-10 sec into Anthropic SSE response). Root cause = OneCLI MITM proxy + agent-runner stream-handling mismatch with current OneCLI/SDK.
+2. **Shadow v2 on VPS-1** (`/home/limitless/nanoclaw-v2/`) is bootstrapped and runs cleanly, OneCLI-integrated, CLI-socket-bound — but every chat request fails 400 from Anthropic with `system.2.cache_control.ephemeral.scope: Extra inputs are not permitted`.
+3. **Adding the missing `prompt-caching-scope-2026-01-05` beta header** moves the error to `context_management: Extra inputs are not permitted` — i.e., `claude-agent-sdk` 0.2.116+ emits MULTIPLE forward-compat fields that require multiple beta headers, none of which our OneCLI-injected set currently includes.
+4. **Pinning SDK to 0.2.76** (matching prod) doesn't fully fix shadow v2 either — v2's `container/agent-runner/src/providers/claude.ts:275` uses `systemPrompt: { type: 'preset', preset: 'claude_code', append: instructions }`, and the `claude_code` preset itself emits the scoped cache fields regardless of SDK version.
+
+## Three Architect convergence on root cause
+
+- **Visual Tutor** (CEO's external) — primary: add beta header; fallback: pin SDK 0.2.76
+- **OpenClaw Director (gpt-5.5)** — primary: pin SDK 0.2.76; fallback: add beta header
+- **Director (CC session)** — both confirmed empirically; both have gaps; the CORE issue is v2's USE OF the SDK preset, not just SDK version
+
+OpenClaw's deeper synthesis (Discord, 2026-04-25T07:48Z) is the operational thesis Phase 0 builds on:
+
+> "Old SDK tolerated our prompt shape. New SDK added semantics (`SYSTEM_PROMPT_DYNAMIC_BOUNDARY` distinguishes stable/cacheable system prompt from dynamic per-run content). Our beta-header path is incomplete. Pinning is the safe short-term unblock. Prompt/beta alignment is the durable fix."
+
+## Phase 0 goal
+
+**Get a clean, vanilla NanoClaw v2 install fully operational against the latest claude-agent-sdk + Anthropic API, with NO LIMITLESS customizations and FULL SDK compliance.** Document exactly what compliance means in our environment. Establish a baseline that every future customization PR will be measured against.
+
+Not a goal of Phase 0: porting any v1 customization. Not a goal: fixing prod 1.2.53. Not a goal: changing OAuth token to API key. Not a goal: re-installing channel adapters beyond CLI.
+
+## Phase 0 deliverables (in order)
+
+### Deliverable 0.1 — SDK Compliance Brief
+
+**Output:** `docs/superpowers/specs/2026-04-25-nanoclaw-v2-sdk-compliance-brief.md` (~1500-3000 words). Author = you (Infra Architect). Reviewer = main-ops Architect (when available) OR Director.
+
+**Contents:**
+
+1. **SDK request anatomy** — exhaustive enumeration of every field `@anthropic-ai/claude-agent-sdk@latest`'s `query()` emits in the outbound `/v1/messages?beta=true` request body. Group by: stable (always-accepted), beta-gated (require specific `anthropic-beta` header), and version-specific (introduced/removed in specific SDK versions).
+2. **`SYSTEM_PROMPT_DYNAMIC_BOUNDARY` semantics** — what it is, when the SDK uses it, what marker it inserts, what gets cached vs not, what `scope: "global"` means. Reference SDK source `/home/limitless/nanoclaw-v2/container/agent-runner/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs` if needed.
+3. **Beta-header matrix** — for each beta-gated field, what `anthropic-beta` value enables it. Include known: `prompt-caching-2024-07-31`, `extended-cache-ttl-2025-04-11`, `oauth-2025-04-20`, `prompt-caching-scope-2026-01-05`, `context_management-???`. Find any others by inspecting SDK source + Anthropic docs + community signals.
+4. **Auth-mode gating** — what's enabled for `sk-ant-oat01-` consumer OAuth vs `sk-ant-api-` org API key. Specifically: does `prompt-caching-scope-2026-01-05` work with our consumer OAuth? Test empirically with a single direct curl through the OneCLI gateway.
+5. **Streaming contract** — how the SDK consumes SSE responses; what timeouts apply; how OneCLI's MITM proxy interacts with long streams.
+6. **`systemPrompt` API** — preset modes (`'claude_code'` vs others vs raw) — what each does, what fields each emits, how to construct a custom system prompt that AVOIDS the beta-gated fields if compliance can't be achieved through headers alone.
+
+**Definition of done:** the brief is exhaustive enough that a new operator could read it and configure a working v2 deployment from scratch.
+
+### Deliverable 0.2 — Compatibility Matrix Test
+
+**Output:** `docs/superpowers/specs/2026-04-25-nanoclaw-v2-compatibility-matrix.md` + a test script (`/home/limitless/nanoclaw-v2/scripts/sdk-compat-probe.ts` or similar) that empirically verifies each cell.
+
+**Matrix cells (SDK version × beta header set × auth mode × prompt complexity):**
+
+| SDK version | Beta headers | Auth | Prompt | Expected |
+|---|---|---|---|---|
+| 0.2.76 (prod) | current 3 | OAuth | simple | ✅ 200 |
+| 0.2.76 | current 3 | OAuth | claude_code preset | ❌ 400 (already confirmed today) |
+| 0.2.119 (latest) | current 3 | OAuth | claude_code preset | ❌ 400 cache_control.scope |
+| 0.2.119 | + `prompt-caching-scope-2026-01-05` | OAuth | claude_code preset | ❌ 400 context_management (confirmed today) |
+| 0.2.119 | + scope + context_management beta (TBD) | OAuth | claude_code preset | ? |
+| 0.2.119 | full identified beta set | OAuth | NO preset, raw system | ? — if works, we have a path |
+| 0.2.119 | full identified beta set | API key | claude_code preset | ? — control for OAuth gating |
+
+**Definition of done:** every cell has an empirical result + a documented explanation. Identifies the COMPLIANT configuration for our environment.
+
+### Deliverable 0.3 — Working Shadow v2 (verification)
+
+Apply the compliant configuration from 0.2 to `/home/limitless/nanoclaw-v2/`. Demonstrate:
+
+1. Short prompt round-trip success
+2. Long prompt (~3000 chars system + ~2000 chars user) round-trip success
+3. Streaming response completes cleanly
+4. Tool use (Read, Bash, WebFetch) works
+5. Multi-turn conversation works
+6. Container exits cleanly with code 0 (not 137) after task completion
+
+If any test fails: extend the SDK Compliance Brief with the new finding + iterate.
+
+### Deliverable 0.4 — NanoClaw v2 Prompt Contract
+
+**Output:** `docs/superpowers/specs/2026-04-25-nanoclaw-v2-prompt-contract.md` (~800-1500 words).
+
+Per OpenClaw's recommendation:
+- **Static section** (before `SYSTEM_PROMPT_DYNAMIC_BOUNDARY` if used, or as cacheable-marked blocks): Architect identity, stable operating rules, app scope, tool definitions
+- **Dynamic section** (after boundary, no cache_control): Discord message, channel metadata, task context, volatile session state, time-sensitive data
+- **Explicit anti-rules**: no secrets in cacheable blocks, no per-run state in static, no large mutable contexts in cacheable blocks
+
+This contract becomes the canonical structure that all future Architect CLAUDE.md content will be authored against.
+
+### Deliverable 0.5 — v1 Customization Inventory (NOT YET PORTED)
+
+**Output:** `docs/superpowers/specs/2026-04-25-v1-customizations-to-evaluate.md` (~1000-2000 words).
+
+Exhaustive list of LIMITLESS-specific changes in our 1.2.53 fork that diverge from upstream v2. For each:
+- What it does
+- Why we added it (link to PR, DR, or memory)
+- Whether v2 still needs it (vs upstream-equivalent feature)
+- Port priority: must-have / nice-to-have / drop
+- Estimated port effort
+
+Categories to cover:
+- DR-001 Phase 3 (limitless-agent[bot] App identity + token minting)
+- DR-002 (monorepo-as-source-of-truth)
+- Per-app Architect topology (5 Architects + main-ops)
+- Discord channel topology + bot setup (TRUSTED_BOT_IDS, allowBots, requireMention)
+- Custom CLAUDE.md fragments per Architect
+- Governance integration (CODEOWNERS ratification, §5.5 attestation, ruleset 15502000)
+- Node 24 + better-sqlite3 12.3.0 (just landed via PR #105)
+- Host Relay Surface (PR #89 DRAFT)
+- Any custom container-runner.ts modifications
+- Any custom agent-runner-src per group
+
+**Phase 1+ work** (NOT PART OF PHASE 0): port these one-by-one against the green Phase 0 baseline, with PR + ratification per port.
+
+## Streaming-bug awareness — work in small chunks
+
+You (Infra Architect) experienced today that long-output tasks die mid-stream when run through prod 1.2.53. Phase 0's deliverables are LARGE specs. To avoid losing work to streaming death:
+
+- **Stash work-in-progress to `/workspace/group/drafts/` AS YOU GO** (per `feedback_persistent_storage_for_work_products.md`)
+- **Break large deliverables into smaller PRs** — one PR per deliverable section if needed
+- **Verify each PR is mergeable before continuing to the next** — don't accumulate weeks of unmerged work
+
+If a session dies mid-deliverable: resume in a fresh container, read the stash, continue. The work is preserved.
+
+## Working environment
+
+**Don't touch prod 1.2.53.** It's degraded but operational. Phase 0 work happens in:
+- `/home/limitless/nanoclaw-v2/` on VPS-1 — already cloned, deps installed, image built, OneCLI integrated, service running. Use this for compatibility-matrix testing + arriving at the green configuration.
+- Read-only inspection of `/home/limitless/nanoclaw/` (prod) is fine for comparing against the v2 baseline.
+
+**OneCLI gateway**: shared between prod and shadow. Both are routed cleanly via separate agents (`Default Agent` for prod, `cli-with-director` for shadow). Don't reconfigure shared OneCLI without coordinating with Director.
+
+**Anthropic credentials**: `sk-ant-oat01-` OAuth token is what's currently in OneCLI's vault. Do NOT swap to API key without CEO ratification — that's a Phase 1+ decision.
+
+## Authority + governance
+
+This handoff authorizes execution: you can write code, modify v2 install, run tests, push PRs, restart shadow v2 service. You may NOT touch prod 1.2.53 without Director coordination.
+
+Each deliverable PR follows normal governance:
+- §5.5 attestation in PR body
+- CODEOWNER review (CEO via formal Approving Review per ruleset id 15502000)
+- Squash-merge
+
+If you hit a blocker requiring CEO decision: surface to #main-ops with the BLOCKER message format from `feedback_blocker_surface_latency.md`.
+
+## Related artifacts (for context)
+
+- Multi-environment Architect pipeline proposal: `docs/superpowers/proposals/2026-04-25-multi-environment-architect-pipeline.md` — Phase 0 is implicitly using shadow v2 as the Test environment for v2 work
+- Cache control investigation handoff: `docs/superpowers/proposals/2026-04-25-cache-control-scope-investigation-handoff.md` — research origin of today's 400 errors (Visual Tutor + OpenClaw Director responses on file)
+- DR-001 Phase 3: `project_agent_identity_dr001.md` (memory) — the App-token minting we'll need to port in Phase 1
+- DR-002: `project_nanoclaw_source_of_truth_dr002.md` (memory) — monorepo deploy posture
+- v2 upstream CHANGELOG entry: https://github.com/qwibitai/nanoclaw/blob/main/CHANGELOG.md (v2.0.0 section)
+- `@anthropic-ai/claude-agent-sdk` on npm: https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk
+
+## Definition of Phase 0 success
+
+When ALL of the following are true:
+1. ✅ SDK Compliance Brief published as a spec
+2. ✅ Compatibility matrix has empirical results for every cell + a clearly identified COMPLIANT configuration
+3. ✅ Shadow v2 demonstrates working short, long, streaming, tool-use, and multi-turn flows under the compliant config
+4. ✅ Prompt Contract spec defines the static/dynamic structure all future Architects will follow
+5. ✅ v1 Customization Inventory exists as a planning artifact for Phase 1
+
+THEN Phase 1 (selective customization port) can begin.
+
+---
+
+*Director-drafted. Picked up by NanoClaw Infra Architect at CEO's direction (2026-04-25T10:41Z, #main-ops). OpenClaw Director (gpt-5.5) is available as a parallel analysis resource — feel free to dispatch sub-questions to them via Director if useful, but you are the executor.*

--- a/docs/superpowers/proposals/2026-04-25-shadow-architect-oauth-research-response.md
+++ b/docs/superpowers/proposals/2026-04-25-shadow-architect-oauth-research-response.md
@@ -1,0 +1,276 @@
+# Shadow Architect OAuth Research Response
+
+Date: 2026-04-25
+Author: OpenClaw Director
+Status: Research-only response, no execution performed
+Handoff: `/home/limitless/.openclaw/workspace/docs/superpowers/proposals/2026-04-25-shadow-architect-oauth-research-handoff.md`
+
+## Executive summary
+
+The best fourth path is **not** to extend the direct OAuth subprocess into a long internal agent loop. The strongest path is to switch the shadow Architect to a **Meridian-style SDK-compliant passthrough proxy architecture**: keep Claude Max OAuth, avoid OneCLI TLS MITM, let the Claude Agent SDK operate with its expected low-turn/passthrough pattern, and let NanoClaw or an adapter execute tools between requests.
+
+The key finding is that the observed “2-turn ceiling” may not be an arbitrary bug. Meridian’s source explicitly treats **2 turns as the base budget for passthrough mode**: turn 1 generates tool-use blocks, turn 2 processes the blocked-tool handoff. Meridian makes that usable by returning tool calls to the client and resuming across requests. NanoClaw direct-bypass appears to be trying to run a full internal multi-turn engineering loop through a subscription-OAuth session, then dies when the SDK/account path wants to hand control back.
+
+Top candidate paths:
+
+1. **Meridian-style passthrough replacement for OneCLI** — highest confidence, fastest path to a compliant OAuth shadow if NanoClaw can call an Anthropic-compatible local proxy or be adapted to tool passthrough.
+2. **Minimal non-MITM reverse proxy for header normalization + SSE preservation** — technically likely to fix OneCLI’s streaming failure, but must be governed carefully because using header shape to alter rate-limit treatment may be policy-sensitive.
+3. **Pin / configure SDK into older or safer behavior while compatibility work proceeds** — useful fallback, but unlikely to solve the direct-OAuth multi-turn ceiling if the ceiling is account/SDK semantic rather than SDK bug.
+
+I found no strong evidence for an env var, `.claude/settings.json` switch, OAuth token exchange, or Console setting that safely converts Claude Max OAuth into unlimited API-style long internal agent loops.
+
+## Evidence reviewed
+
+### Local / prior evidence
+
+- Handoff documents two empirical failure modes:
+  - OneCLI MITM mode: upstream `200 text/event-stream` then MITM connection error after ~3 seconds.
+  - OneCLI bypass mode: direct `Authorization: Bearer <sk-ant-oat01>` emits `rate_limit_event` after exactly 2 assistant turns, then process exits 137 without `result` for non-trivial tasks.
+- Prior local SDK inspection found NanoClaw v2 using `@anthropic-ai/claude-agent-sdk@0.2.119`.
+- Prior research found `cache_control.scope` beta/header mismatch and Meridian/opencode-with-claude as relevant OAuth proxy prior art.
+
+### Meridian source/docs evidence
+
+From public Meridian README and source fetched from GitHub:
+
+- Meridian “bridges the Claude Code SDK to the standard Anthropic API.” It routes through the official SDK `query()` path and exposes Anthropic/OpenAI-compatible HTTP endpoints.
+- `src/proxy/server.ts` imports `query` from `@anthropic-ai/claude-agent-sdk` and strips `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, and `ANTHROPIC_AUTH_TOKEN` from the SDK subprocess env so the subprocess uses native Claude auth rather than looping through the proxy.
+- `src/proxy/query.ts` builds SDK options centrally.
+- Meridian has explicit SDK feature controls: `settingSources`, `codeSystemPrompt`, `clientSystemPrompt`, `memory`, `dreaming`, `sharedMemory`, `betas`, `maxBudgetUsd`, etc.
+- `src/proxy/query.ts` contains a critical passthrough note: base passthrough mode uses 2 turns because turn 1 generates tool-use blocks and turn 2 processes the blocked-tool handoff. Resume/deferred tools/advisor increase this small budget.
+- `src/proxy/betas.ts` filters beta headers by profile. For `claude-max`, default policy is `allow-safe`: strip known billable betas such as `extended-cache-ttl-*`, while forwarding safe betas required for SDK behavior. It also supports `MERIDIAN_BETA_POLICY=strip-all|allow-safe|allow-all`.
+
+These facts strongly suggest Meridian is not “making Max OAuth unlimited.” It is **structuring the agent loop so Max OAuth can operate in short SDK-compatible turns**, while the proxy/client manages continuity.
+
+## Q1 — SDK / Claude Code config that extends per-session ceiling
+
+### Finding
+
+I found **no credible config knob that extends a Claude Max OAuth direct subprocess into an unrestricted internal multi-turn engineering loop**.
+
+Relevant SDK/CLI observations:
+
+- The Agent SDK exposes `maxTurns` as an option/CLI flag, but that is a client-side runaway limit, not an account quota uplift.
+- Claude Code contains UI/commands around rate limits, including `rate-limit-options`, `/upgrade`, “extra usage,” and plan upgrade flows.
+- CLI code indicates if already on the highest Max plan, the suggested path for additional usage is to log in with an API usage-billed account. That is explicitly not the CEO’s desired path.
+- The SDK emits `rate_limit_event` separately from normal result events; NanoClaw’s adapter currently ignores `rate_limit_event` in some UI contexts, but the subprocess exit still occurs.
+
+### Conclusion
+
+No Q1 option looks like a safe “increase per-session ceiling” switch. Increasing `maxTurns` cannot overcome subscription/account rate-limit events. A setting to “not exit on rate_limit_event” would not solve the underlying lack of allowed follow-on inference.
+
+### Estimated implementation time if pursued
+
+Not recommended. Further source spelunking could take 1-2 hours, but likely yields no working path.
+
+## Q2 — Alternative MITM-free credential-injection middleware
+
+### Finding
+
+A non-MITM reverse proxy can likely solve **the SSE truncation** part of Path A, because OneCLI’s failure mode appears tied to TLS MITM stream handling, not to Anthropic or the SDK itself.
+
+Candidate classes:
+
+1. **Meridian**
+   - Already a local HTTP proxy.
+   - Designed for Claude Max OAuth + SDK.
+   - Does not need TLS MITM against `api.anthropic.com`.
+   - Preserves streaming and session behavior by design.
+
+2. **Minimal Node/Hono/Fastify reverse proxy**
+   - Accept local Anthropic-compatible requests.
+   - Rewrite/normalize auth headers.
+   - Forward to Anthropic or SDK.
+   - Preserve SSE with streaming response piping.
+   - Fast to write, but would be new custom infra.
+
+3. **nginx / Envoy / mitmproxy**
+   - Can preserve SSE if configured correctly (`proxy_buffering off`, long read timeouts, no response buffering).
+   - Good if the only requirement is header injection and streaming pass-through.
+   - Less aligned with SDK semantics than Meridian.
+
+4. **LiteLLM / Cloudflare AI Gateway**
+   - Possible, but may add translation complexity and beta-header/auth edge cases.
+   - Less attractive for same-day recovery.
+
+### Caution
+
+If the goal is explicitly to use `x-api-key` header shape to obtain “API-class” behavior from an OAuth token, that may be policy-sensitive. I recommend framing this as **header normalization required by the SDK/proxy contract**, not as an attempt to bypass subscription limits. The safer route is Meridian-style SDK-native OAuth behavior.
+
+### Conclusion
+
+Q2’s best concrete candidate is **Meridian**, not a generic MITM replacement. If Meridian cannot be integrated fast enough, a minimal SSE-safe reverse proxy is the backup technical pattern.
+
+### Estimated implementation time
+
+- Meridian spike: 1-3 hours if it can run locally and NanoClaw can point at an Anthropic-compatible base URL.
+- Custom reverse proxy: 2-4 hours plus validation, higher governance risk.
+
+## Q3 — OAuth token exchange / sidechannel that elevates per-session limits
+
+### Finding
+
+No credible evidence found for a safe OAuth token exchange, query parameter, billing header, or scope upgrade that converts Claude Max OAuth into API-class long-session behavior while staying on the same subscription route.
+
+The Claude Code source does include OAuth refresh handling and account metadata such as subscription type/rate-limit tier. It also includes upgrade/extra-usage UI paths. But those are product/account flows, not a documented token exchange to bypass rate limits.
+
+### Conclusion
+
+Do not pursue Q3 as an engineering path. If Anthropic supports such an uplift, it should come through official account/support/Console channels, not reverse-engineered headers.
+
+### Estimated implementation time
+
+Not recommended.
+
+## Q4 — Meridian as drop-in replacement for OneCLI
+
+### Finding
+
+Meridian is the strongest fourth path.
+
+Why:
+
+- It was built for exactly this family of problem: Claude Max/Pro OAuth with tools that expect Anthropic/OpenAI-compatible HTTP APIs.
+- It avoids OneCLI’s TLS MITM failure mode.
+- It uses the official Claude Agent SDK `query()` path.
+- It understands Max vs API profiles.
+- It has beta filtering specific to Max subscription behavior.
+- It intentionally models passthrough mode with a 2-turn base budget, which matches the empirical “2 turns then rate limit event” clue.
+
+The key architectural question is whether NanoClaw v2 can act like a client of Meridian:
+
+- If NanoClaw v2 can send Anthropic-compatible requests to a local base URL, Meridian may be a near drop-in replacement for OneCLI.
+- If NanoClaw v2 is itself calling `@anthropic-ai/claude-agent-sdk query()` directly, then Meridian is not drop-in at the current seam. The seam would need to move: either NanoClaw calls Meridian as an API, or NanoClaw adopts Meridian’s passthrough/session design internally.
+
+### Most important insight
+
+Meridian probably does **not** solve this by extending direct OAuth turn limits. It solves it by **not trying to run the whole engineering loop inside one long direct OAuth subprocess**. In passthrough mode, tool calls return to the client; the client executes tools and submits the next request/session continuation.
+
+### Conclusion
+
+Make Meridian the primary recovery spike. The goal should be:
+
+> Replace OneCLI as the OAuth/SSE bridge with Meridian or replicate Meridian’s passthrough pattern, so the shadow Architect operates as a client-managed multi-request agent rather than a single long internal Claude Code subprocess.
+
+### Estimated implementation time
+
+- Read-only confirmation of NanoClaw seam: 30-60 minutes.
+- Run Meridian local spike: 1-2 hours after approval.
+- Integrate as shadow-only base URL: 1-3 hours if compatible.
+- If NanoClaw requires deeper adapter changes: same-day possible but riskier, 4-8 hours.
+
+## Q5 — Anthropic Console per-account configuration uplift
+
+### Finding
+
+No evidence found for a simple Console setting that increases per-session Max OAuth agent-loop limits. Claude Code’s own UI includes `/upgrade`, Max-tier detection, and extra-usage paths, but highest Max appears to direct users toward API usage-billed login for additional usage.
+
+Possible legitimate account-level paths:
+
+- Upgrade from lower Max/Pro tier to higher Max tier, if not already at highest.
+- Enable/request extra usage if account type supports it.
+- Contact Anthropic support/account team for higher limits or enterprise/team plan behavior.
+
+### Conclusion
+
+Q5 is not a same-day engineering fix unless the account is not already on the highest Max tier or has an available extra-usage toggle. It is worth checking manually, but do not block the engineering path on it.
+
+### Estimated implementation time
+
+Manual account check: 5-15 minutes by an authenticated human.
+
+## Q6 — Container-side `.claude/settings.json` rate-limit handling
+
+### Finding
+
+No evidence found that `.claude/settings.json` can override subscription rate limits or prevent subprocess exit after a rate-limit event.
+
+Relevant settings/features can affect:
+
+- auto-memory
+- auto-dreaming
+- CLAUDE.md loading
+- prompt/system behavior
+- tool permissions
+- telemetry/header helpers
+- model/effort/thinking
+
+But rate limits are account/server-side. Settings may reduce token pressure or disable features that trigger extra turns, but they cannot turn a Max OAuth account into API-class capacity.
+
+### Useful setting-adjacent path
+
+Container settings may still matter for stability:
+
+- Disable or minimize auto-memory/dreaming/CLAUDE.md if they add hidden turns or prompt complexity.
+- Use minimal safe betas.
+- Avoid extended-cache TTL on Max unless proven needed.
+- Ensure `maxTurns` is set intentionally for passthrough vs internal mode.
+
+### Conclusion
+
+Q6 is a tuning/mitigation path, not the fourth path.
+
+### Estimated implementation time
+
+Read-only audit: 30 minutes. Safe config experiment after approval: 30-60 minutes.
+
+## Ranked recommendations
+
+### 1. Primary: Meridian-style passthrough bridge
+
+**Path:** Run or adapt Meridian as the OAuth/SSE bridge and have shadow NanoClaw operate against it in Anthropic-compatible client mode, or copy Meridian’s pattern into the v2 shadow adapter.
+
+**Why:** It is aligned with the official SDK, handles Max-vs-API profile differences, avoids OneCLI MITM, and explains the 2-turn observation as an expected passthrough-loop budget rather than a fatal blocker.
+
+**Validation:**
+
+1. Confirm whether NanoClaw v2 can use `ANTHROPIC_BASE_URL` or equivalent to hit a local Anthropic-compatible endpoint instead of direct SDK process mode.
+2. If yes, test against Meridian with OAuth profile.
+3. If no, compare NanoClaw’s SDK direct usage to Meridian `buildQueryOptions()` and add/replicate passthrough mode.
+
+**Time-to-implement:** 1-3 hours if endpoint seam exists; 4-8 hours if adapter changes are required.
+
+### 2. Backup: SSE-safe local reverse proxy replacing OneCLI MITM
+
+**Path:** Keep the working auth/header posture of OneCLI mode but replace the TLS MITM streaming layer with a simple local reverse proxy that preserves SSE.
+
+**Why:** OneCLI mode’s blocker is stream truncation, not auth. A normal reverse proxy can stream indefinitely if configured correctly.
+
+**Risks:** Must avoid intentionally bypassing service limits. Must confirm ToS/policy posture. Does not fix SDK semantics as cleanly as Meridian.
+
+**Time-to-implement:** 2-4 hours.
+
+### 3. Mitigation: SDK/prompt/beta minimization
+
+**Path:** Keep OAuth direct but reduce hidden turn pressure: disable optional features, minimize betas, pin SDK if needed, avoid auto-memory/dreaming/extended cache TTL.
+
+**Why:** May allow slightly larger tasks, but unlikely to deliver full Architect capability if the 2-turn direct-OAuth pattern is structural.
+
+**Time-to-implement:** 1-2 hours of experiments, uncertain payoff.
+
+## Specific tests to run after approval
+
+1. **Meridian smoke test**
+   - Start Meridian with the same Claude OAuth account.
+   - Send an Anthropic-compatible streaming request long enough to exceed 3 seconds.
+   - Confirm SSE does not truncate.
+
+2. **Meridian tool passthrough test**
+   - Use a simple tool-call workflow.
+   - Confirm the model returns tool calls, client executes, and next request resumes successfully.
+
+3. **NanoClaw seam test**
+   - Determine whether NanoClaw v2 can point to a custom Anthropic base URL without invoking its own SDK subprocess directly.
+
+4. **Beta policy test**
+   - Compare current headers against Meridian `allow-safe`: especially strip `extended-cache-ttl-*` on Max.
+
+5. **Direct OAuth ceiling confirmation**
+   - Run the same multi-turn prompt through direct SDK internal mode with maxTurns high.
+   - If it still rate-limits after 2 turns, treat direct internal OAuth mode as non-viable for full Architect work.
+
+## Final answer
+
+The fourth path is **not** “find a hidden flag to make OAuth direct unlimited.” The fourth path is **change the architecture to match how working Claude Max OAuth bridges operate**: a local SDK-compliant proxy/passthrough loop, with Meridian as the reference and likely fastest implementation candidate.
+
+If CEO requires a fully functional OAuth shadow Architect today, I recommend prioritizing **Meridian-as-OneCLI-replacement / Meridian-style passthrough** immediately.

--- a/docs/superpowers/retros/2026-04-25-meridian-diff-and-option-d-integration-verification.md
+++ b/docs/superpowers/retros/2026-04-25-meridian-diff-and-option-d-integration-verification.md
@@ -1,0 +1,210 @@
+---
+name: Bundled retrospective — Meridian-diff incident + Option D / integration-verification lessons
+authored-by: Director (CC session)
+ratified-by: pending CEO
+covers-incidents: 2026-04-25 fleet breakage + cache_control 400, 2026-04-23 Option D PR-#73-regression rollback
+created: 2026-04-25
+related-memories: feedback_canonical_docs_first.md, feedback_diff_against_working_reference.md, feedback_no_proxy_header_injection.md, feedback_verification_first.md, feedback_prefer_rigor_over_speed.md
+related-specs: 2026-04-25-sdk-contract-proxy-as-interop-layer.md
+related-plans: 2026-04-25-v2-streaming-bug-onecli-fallback-patch.md
+related-proposals: 2026-04-25-multi-environment-architect-pipeline.md, 2026-04-25-nanoclaw-v2-phase-0-sdk-compliance-handoff.md
+---
+
+# Bundled Retrospective — 2026-04-23/25 Integration-Verification Arc
+
+## Why bundled
+
+CEO requested on 2026-04-23 that the Option D / PR-#73-regression
+retrospective be deferred until the Infra audit returned. Before that
+audit landed, the 2026-04-25 fleet incident happened. Both incidents
+share a single root meta-pattern: **single-environment systems where
+verification is conflated with PR-passing and where canonical
+references aren't consulted before debugging.** Bundling them captures
+the meta-pattern with two reinforcing instances.
+
+## Incident #1 — 2026-04-23 PR #73 regression cascade
+
+**Arc summary:**
+
+- PR #73 (NanoClaw 1.2.46→1.2.53 upstream sync) merged 2026-04-22 with
+  green CI. Three downstream regressions surfaced over the next 24
+  hours:
+  1. 4 cascading test-mock integrity defects in
+     `container-runner.test.ts`
+  2. Missing `pnpm-lock.yaml` regen for `@octokit/auth-app`
+  3. `apps/nanoclaw/package.json` missing `discord.js` dep while
+     `src/channels/discord.ts` still imported it
+- MVAP (Manual Verification Action Plan) Step 1 was attempted on VPS-1
+  on 2026-04-23 ~19:35 UTC. Phases 1-4.5 executed cleanly; Phase 5
+  (`pnpm run build`) revealed regression #3 above.
+- CEO invoked Option D ("stability and predictability are core
+  principles, worth time+resources"). Rollback was clean — service up
+  on fork code, zero data loss, no config drift.
+- Root cause: PR #73 merged with CI passing because CI didn't exercise
+  the production build path. The `tsc` step that would have caught the
+  missing dep wasn't in CI.
+
+**Lesson surface:**
+- "PR passes CI" ≠ "code is integration-verified". CI exercises a
+  subset; integration with the prod build/runtime path is a different
+  contract.
+- A single environment (prod) has no place to discover this gap before
+  it bleeds into prod recovery time.
+
+## Incident #2 — 2026-04-25 cache_control 400 + fleet streaming death
+
+**Arc summary:**
+
+- PR #105 (Week 1 Node 24 migration) deployed 2026-04-24 07:59 UTC
+  with green CI and a clean systemd service start.
+- Symptom started immediately: NanoClaw fleet's Architect containers
+  died at code 137 within 7-13 sec of spawn. Surface stayed silent for
+  ~8 hours because proactive checks fail-silently and Director didn't
+  notice until 2026-04-25 morning Discord traffic.
+- ~24 hours of CEO + Director debug surfaced TWO distinct root causes:
+  - **Cause A**: OneCLI proxy was injecting a static `anthropic-beta`
+    header that overrode the coherent header constructed by
+    `claude-agent-sdk` 0.2.116+. The body fields the SDK emitted
+    (`cache_control.ephemeral.scope`, `context_management`) were
+    rejected by Anthropic API because the proxy-injected header didn't
+    enable them.
+  - **Cause B**: OneCLI's MITM proxy disconnects ~3 sec into streaming
+    SSE responses from `api.anthropic.com`. Independent of Cause A.
+- **Cause A fixed** by deletion of the `Anthropic Beta Header` OneCLI
+  secret. Verified working: shadow v2 returned a coherent ~700 char
+  response in 9 sec.
+- **Cause B remains** — affects long-streaming responses on both prod
+  1.2.53 and shadow v2. Fix planned in
+  `2026-04-25-v2-streaming-bug-onecli-fallback-patch.md`.
+
+**Lesson surface:**
+- Whac-a-mole field-by-field debugging is a sign that the working
+  hypothesis is wrong. Each fix moving the error to the next field
+  means the fix doesn't address the root.
+- A working reference implementation (Meridian) was a 15-minute read
+  away. Reaching for it earlier would have collapsed ~10 hours of
+  hypothesis-testing into ~30 minutes of diff-and-verify.
+- Single-environment systems concentrate ALL failure modes onto the
+  CEO-facing prod surface. The 8-hour blast-radius surfacing latency
+  is a structural property of single-env, not a Director attention bug.
+
+## Common meta-pattern across both incidents
+
+| Dimension | Incident #1 | Incident #2 |
+|---|---|---|
+| Where the gap lived | CI ≠ integration-verification | OneCLI ≠ SDK contract surface |
+| Why it surfaced in prod | No Test environment | No Test environment |
+| Why debug took long | No reference comparison | No reference comparison |
+| What the fix proved | Rollback strategy works | Header deletion works |
+| What couldn't be fixed without Test env | The class of regression | The class of drift |
+
+**Both incidents are instances of the same meta-pattern**: missing
+defense-in-depth between PR-merge and prod-impact, plus debug-by-
+hypothesis instead of debug-by-reference-comparison.
+
+## What worked (keep doing)
+
+1. **Option D ("rigor over speed")** during incident #1. Rolling back
+   cleanly preserved the system's stability/predictability invariants
+   even at cost of additional cycle time. CEO's framing ("worth time +
+   resources") was correct.
+
+2. **CEO insight as escalation path**. In incident #2, CEO surfacing
+   Meridian as a reference was the breakthrough. Director hadn't
+   reached for an external reference; CEO did. The CEO-as-final-
+   reasoner pattern works.
+
+3. **Multi-agent corroboration**. Visual Tutor + OpenClaw Director +
+   in-session Director triangulating root causes converged correctly.
+   Director synthesizing into the SDK Compliance handoff captured the
+   shared diagnosis.
+
+4. **Three-layer artifact discipline**. Each incident produced a
+   topic-file memory + handoff document + (now) spec/retro. Future
+   sessions inherit the full trail.
+
+5. **Persistent storage of WIP** (per
+   `feedback_persistent_storage_for_work_products.md`). Shadow v2
+   bootstrapped + state-preserved across multiple Director session
+   resumes despite OneCLI streaming death killing one mid-task.
+
+## What failed (stop doing)
+
+1. **PR-passing-CI conflated with integration-verified**. PR #73 merged
+   green; PR #105 merged green. Both shipped real prod defects
+   immediately.
+
+2. **Hypothesis-first debugging on integration class issues**. Spent
+   ~10 hours testing field-by-field theories on cache_control before
+   reaching for Meridian. The 80/20 was reversed.
+
+3. **Manual proxy header injection at OneCLI**. The static
+   `anthropic-beta` secret was a structural bug — would have failed
+   eventually no matter what version-pin we picked.
+
+4. **Single-environment posture for a software product (NanoClaw fleet
+   itself)**. Same posture is unacceptable for any other dev project
+   in the org. Pipeline gap was already visible in retrospect.
+
+## What to try (new ideas)
+
+1. **Multi-environment Architect pipeline (P0)** — proposal at
+   `2026-04-25-multi-environment-architect-pipeline.md`. Dev → Test →
+   Staging → Prod for the agentic-team-as-software-product. Defends
+   against both incident classes structurally.
+
+2. **Reference-implementation-first debug protocol** — when stuck on
+   integration X for >2 hypotheses, find a known-working reference
+   implementation and DIFF first. Memory:
+   `feedback_canonical_docs_first.md` and
+   `feedback_diff_against_working_reference.md`.
+
+3. **SDK-contract-as-spec discipline** — proxy/gateway code that
+   touches an SDK-API wire format must be governed by a binding spec
+   (now: `2026-04-25-sdk-contract-proxy-as-interop-layer.md`). New
+   such code is not mergeable without spec compliance.
+
+4. **Build-step in CI** for any monorepo PR that touches a service.
+   `pnpm run build` + `pnpm run typecheck` in CI before merge would
+   have caught PR #73's three regressions on green-CI machine.
+   (Already on the existing governance amendments queue per
+   2026-04-23 session memory.)
+
+5. **End-to-end smoke test post-deploy**. The 8-hour latency on
+   incident #2 surface was because nothing pinged a fresh Architect
+   spawn after the Node 24 deploy. A 60-second smoke test (spawn an
+   Architect; have it return "ok"; tear down) catches Cause-A-class
+   regressions immediately. Already partially aligned with
+   `feedback_verification_first.md` 2026-04-24 amendment; extend.
+
+## Action items
+
+| # | Action | Owner | Deadline | Status |
+|---|---|---|---|---|
+| 1 | Ratify spec `2026-04-25-sdk-contract-proxy-as-interop-layer.md` (CEO formal Approving Review) | CEO | 2026-04-26 | Pending |
+| 2 | Execute v2 streaming-bug patch per plan `2026-04-25-v2-streaming-bug-onecli-fallback-patch.md` | Infra Architect (or Director hand-applied) | 2026-04-27 | Pending |
+| 3 | Refactor v2 `claude.ts` to Meridian's conditional `resolveSystemPrompt` shape (Phase 0 follow-up) | Infra Architect | next dispatch | Pending |
+| 4 | Refine multi-environment pipeline proposal into formal spec | Infra Architect | when fleet operational | Pending |
+| 5 | Add `pnpm run build` + `pnpm run typecheck` to CI for any PR touching `apps/*` (covers PR #73 class) | Infra Architect | next CI PR cycle | Pending |
+| 6 | Add post-deploy E2E smoke test (Architect spawn + roundtrip) — extends `feedback_verification_first.md` 2026-04-24 amendment | Infra Architect | when env-pipeline lands | Pending |
+| 7 | Update SOUL.md / IDENTITY.md / TOOLS.md on OpenClaw with reference-first debug protocol | Director | 2026-04-26 | Pending |
+| 8 | Promote spec to DR-NNN at next governance ratification cycle | CEO | next DR cycle | Pending |
+
+## Director notes
+
+The two incidents bundled here cover a 48-hour arc where the team's
+rigor temperament held under pressure. CEO's "stability and
+predictability are core principles" framing on 2026-04-23 became the
+operational temperament for 2026-04-25's longer debug. Each delay paid
+back in correct root-cause identification and clean recovery.
+
+The specific gaps that remain after this retrospective land as
+governance amendments and pipeline work. They are not Director-level
+fixes; they are platform-level investments. Ratifying spec #1 + executing
+plan #2 are the immediate unblocks for shadow v2 testing.
+
+Open thread for next CEO discussion: should this retrospective land as a
+DR (governance-binding) or as a normal retro (operational record)?
+Recommendation: split — the SDK contract spec is DR-class (binding); the
+retrospective itself is operational (this file). DR ratification covers
+the rule; the retro records the learning.

--- a/docs/superpowers/specs/2026-04-25-sdk-contract-proxy-as-interop-layer.md
+++ b/docs/superpowers/specs/2026-04-25-sdk-contract-proxy-as-interop-layer.md
@@ -1,0 +1,292 @@
+---
+name: SDK Contract — Proxy as Interop Layer (not Header Injection Layer)
+status: SPEC
+authored-by: Director (CC session)
+ratified-by: pending CEO
+originated-from: docs/superpowers/proposals/2026-04-25-cache-control-scope-investigation-handoff.md
+incident-arc: project_2026-04-25_meridian_diff_and_streaming_bug.md
+created: 2026-04-25
+priority: P0 (binding rule for all proxy/gateway code that sits between claude-agent-sdk and api.anthropic.com)
+related-DRs: pending — proposed as DR-NNN once ratified
+applies-to: OneCLI gateway configuration, NanoClaw container-runner, agent-runner provider modules, any future MITM/proxy/gateway between SDK and Anthropic
+---
+
+# SDK Contract — Proxy as Interop Layer (not Header Injection Layer)
+
+## Origin
+
+The 2026-04-25 fleet incident (~24 hours of debug + recovery) traced to a
+single architectural mistake: a generic `anthropic-beta` header injected at
+the OneCLI proxy layer was overriding the coherent header constructed by
+`@anthropic-ai/claude-agent-sdk`. The SDK's request body and the proxy's
+header disagreed, and Anthropic strict-schema-rejected the body fields the
+SDK had assumed enabled.
+
+The fix was the deletion of one secret. The lesson is general enough to
+deserve a binding rule: **a proxy that injects HTTP headers that the SDK
+also computes will always eventually break, because the SDK's body and the
+proxy's header are independent computations that drift over time.**
+
+## The contract
+
+| Layer | Owns |
+|---|---|
+| `claude-agent-sdk` (callee) | Request body shape, `anthropic-beta` header, prompt-cache fields, OAuth bearer construction, retry semantics, SSE consumption |
+| Proxy / gateway (interop layer) | Routing, observability (logs/metrics), credential storage + retrieval, optional response caching, SSL termination, enforcing org-level allow/deny rules |
+| Anthropic API (server) | Schema validation, billing, model selection, response generation |
+
+The SDK and the API are direct counterparties. They communicate over a
+versioned wire format that the SDK author and the API team co-evolve. A
+proxy that *modifies* that wire format puts itself in the middle of a
+contract it has no signing authority on.
+
+## The binding rule
+
+**DO NOT inject `anthropic-beta` at a proxy / gateway layer.**
+
+If the SDK constructs an outbound `anthropic-beta` header, the proxy must
+forward it as-is, OR strip it (with documented reason — see Meridian's
+billing-protection pattern), OR pass an SDK-API option upstream that asks
+the SDK to add a beta. The proxy must not OVERRIDE the SDK's value with a
+proxy-author-chosen string.
+
+### Failure mode (forensic record from 2026-04-25)
+
+OneCLI was configured with a generic-type secret named `Anthropic Beta Header`
+that injected:
+
+```
+anthropic-beta: oauth-2025-04-20,extended-cache-ttl-2025-04-11,prompt-caching-2024-07-31
+```
+
+This secret was added at v1 setup time when SDK 0.2.76 emitted body fields
+that aligned with that header set. The injection mode was **replace**, not
+**merge** — OneCLI overwrote whatever the SDK had constructed.
+
+When `claude-agent-sdk` 0.2.116+ added `cache_control.ephemeral.scope` to
+the request body, the SDK simultaneously bumped its outbound
+`anthropic-beta` header to include `prompt-caching-scope-2026-01-05` (the
+gating beta for that field). The proxy's static-string injection
+**discarded** the SDK's coherent header and wrote the stale 3-beta string.
+
+Anthropic's API enforces strict schema validation against whatever
+`anthropic-beta` value it actually received. With the proxy's stale header,
+`scope` was an unknown field → 400 rejection:
+
+```
+system.2.cache_control.ephemeral.scope: Extra inputs are not permitted
+```
+
+Whac-a-mole on the body fields couldn't fix this because each field
+addition would require yet another beta in the static injection string,
+forever lagging the SDK by one release cycle. The *only* fix is to stop
+injecting at the proxy and let the SDK's header through.
+
+## Reference implementation: Meridian
+
+`https://github.com/rynfar/meridian` is an unofficial proxy with the same
+architecture as our setup (Anthropic-compatible client → proxy → Claude
+subscription OAuth). It demonstrates the contract.
+
+### Header handling — `src/proxy/betas.ts`
+
+Meridian explicitly does NOT inject. It only **filters** — and only with a
+documented reason (Max-tier billing protection):
+
+- `allow-safe` (default): forward all betas EXCEPT `extended-cache-ttl-*`
+  prefixes (which trigger Max-tier Extra-Usage billing)
+- `strip-all`: drop every beta (kill switch for emergencies)
+- `allow-all`: forward all betas unmodified (matches API-key profile)
+
+The default policy preserves the SDK's intent. Operators can opt into
+stricter filtering via `MERIDIAN_BETA_POLICY` env var — never via static
+injection.
+
+### Beta passing into the SDK — `src/proxy/query.ts`
+
+When Meridian *does* want a beta enabled, it passes the `betas` array as an
+SDK option:
+
+```typescript
+...(betas && betas.length > 0 ? { betas: betas as SdkBeta[] } : {}),
+```
+
+The SDK then synthesizes the outbound `anthropic-beta` header coherent
+with the body it emits. This is the only correct way for an upstream layer
+to influence the beta set.
+
+### System prompt — `src/proxy/query.ts:157` (`resolveSystemPrompt`)
+
+Meridian also avoids assumption-based defaults on the SDK's other coherent
+surfaces. `resolveSystemPrompt` makes the `claude_code` preset CONDITIONAL
+on whether the operator opted in:
+
+```typescript
+function resolveSystemPrompt(
+  systemContext: string | undefined,
+  passthrough: boolean,
+  settingSources: SettingSource[] | undefined,
+  codeSystemPrompt: boolean | undefined,
+  clientSystemPrompt: boolean | undefined,
+  cwdNote: string,
+): { systemPrompt?: string | { type: "preset"; preset: "claude_code"; append?: string } } {
+  const hasSettings = settingSources != null && settingSources.length > 0
+  const usePreset = codeSystemPrompt ?? (hasSettings || (!passthrough && !!systemContext))
+  // ...
+  if (usePreset) {
+    return append
+      ? { systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append } }
+      : { systemPrompt: { type: "preset" as const, preset: "claude_code" as const } }
+  }
+  if (append) return { systemPrompt: append }
+  return {}
+}
+```
+
+The contract is: **the preset (which causes the SDK to emit cacheable
+system blocks with version-specific fields) is opt-in**. If you don't
+explicitly want the preset behavior, pass `systemPrompt` as a string and
+the SDK takes a minimal-default code path that doesn't emit those fields.
+
+This is the correct shape. NanoClaw v2's quick-fix on 2026-04-25
+(`systemPrompt: instructions || undefined` + `settingSources: []`) is
+*Meridian-shaped but unconditional* — compliant for the immediate case
+but architecturally weaker. See spec deliverable on
+`apply-meridian-aligned-config-cleanly` (queued).
+
+## Consequences for the LIMITLESS deployment
+
+### MUST (binding)
+
+1. **No `anthropic-beta` injection at OneCLI** for the Anthropic-bound agent.
+   The `Anthropic Beta Header` generic secret (id
+   `84bc6286-52b1-4053-b5fa-0f50826ad5c4`) was deleted on 2026-04-25 and
+   must not be re-added. If a future need to enable a specific beta
+   appears, route it through the SDK option in agent-runner code, not
+   through proxy injection.
+
+2. **OneCLI's role is credential injection only** for Anthropic. Its
+   anthropic-typed secret (id `18646778-e05f-4825-a615-e88893428338`) is
+   the canonical bearer-token source. Anything beyond bearer-injection +
+   SSL routing belongs in agent-runner code.
+
+3. **Beta enablement happens via SDK API**, not headers. When NanoClaw
+   wants a beta enabled (e.g., `prompt-caching-scope-2026-01-05` after
+   we've validated it works for our auth mode), agent-runner passes
+   `betas: [...]` to `query()`. This requires per-version compatibility
+   testing because the SDK may not yet expose new betas as recognized
+   options — see compatibility-matrix work in the Phase 0 SDK Compliance
+   handoff.
+
+4. **`systemPrompt` shape is conditional**, not preset-by-default. Same
+   contract surface as Meridian's `resolveSystemPrompt`. Opt-in to the
+   `claude_code` preset only when the agent NEEDS the cacheable
+   system-context features (auto-memory, settings loading). The current
+   v2 code treats unconditional `string || undefined` as a workaround;
+   Phase 0 deliverable refactors it.
+
+5. **`settingSources` is conditional**, not unconditionally `[]`. Default
+   `undefined` (SDK default) when the agent doesn't need settings;
+   explicit `['project', 'user']` when it does. The Phase 0 refactor
+   makes this an opt-in contract.
+
+### SHOULD
+
+1. **Mirror Meridian's `MERIDIAN_BETA_POLICY` pattern at OneCLI** when
+   forwarding (not injecting): operator-tunable filter for billable
+   betas, default-safe with documented allow-all override. Out of scope
+   for this spec; queued for Infra Architect when OneCLI gains a forward
+   path.
+
+2. **Static-version pin OneCLI** to a release matrix tested against our
+   SDK + Anthropic-API combination. Drifts in any of the three
+   participants must be caught by the multi-environment Architect
+   pipeline (`docs/superpowers/proposals/2026-04-25-multi-environment-architect-pipeline.md`)
+   before reaching prod.
+
+### MAY
+
+1. Forward incoming `anthropic-beta` headers from the SDK with org-policy
+   filtering applied (Meridian's `filterBetasForProfile`-equivalent) once
+   we add a forward path. Filtering with documented reason (e.g., "do
+   not enable extended-cache-ttl on Max accounts because it triggers
+   Extra-Usage billing") is acceptable. Filtering as
+   "operator-thinks-they-know-better-than-the-SDK" is not.
+
+## Detection / regression prevention
+
+A repeat of this incident is structurally guaranteed in a single-environment
+system where header-injection secrets accumulate over time without
+validation against current SDK versions. Two complementary mitigations:
+
+### Code-level
+
+`apps/nanoclaw/src/setup-onecli-secrets.ts` (or equivalent setup script)
+must NOT contain a step that creates a generic-type `anthropic-beta` secret.
+A test (Phase 0 deliverable, `nanoclaw-v2/scripts/sdk-compat-probe.ts` or
+similar) verifies that an outbound request from a smoke-test container
+reaches `api.anthropic.com` with the SDK-constructed header intact (no
+proxy override).
+
+### Environment-level
+
+The multi-environment Architect pipeline (Dev → Test → Staging → Prod)
+catches header-injection regressions in Test before they reach Prod. A
+Test-environment OneCLI configured identically to Prod runs the smoke
+test on every Architect dispatch, surfacing schema-validation 400s as
+build failures.
+
+### Documentation-level
+
+This spec is the canonical reference. CLAUDE.md fragments for any
+agent-runner or OneCLI-touching Architect must link to it.
+
+## Open questions (for next-spec or DR ratification)
+
+1. **OneCLI as a beta forwarder**: when (if ever) does OneCLI gain a path
+   that allows it to forward incoming SDK headers with an `allow-safe`
+   filter? Currently OneCLI is configured via secrets-as-static-headers
+   only; a forwarder mode would require OneCLI feature work.
+
+2. **Pinning OneCLI version per env**: should each environment lock to a
+   tested OneCLI version, with upgrade rehearsal in Test before Staging
+   before Prod? See env-pipeline proposal §"Dependency upgrades follow
+   the same path".
+
+3. **Director / OpenClaw analog**: OpenClaw similarly proxies between
+   `openai-codex` (gpt-5.5) and ChatGPT subscription OAuth. Does the
+   same contract apply there? Likely yes — but ratification scoped to
+   Anthropic-side first; OpenClaw analog deferred.
+
+4. **DR-NNN promotion**: this spec's binding rules deserve a DR record
+   for governance ratification (CEO + CODEOWNER review). Promote on
+   first ratification cycle.
+
+## References
+
+- Incident topic file: `project_2026-04-25_meridian_diff_and_streaming_bug.md`
+  (CEO+Director session memory)
+- Investigation handoff: `docs/superpowers/proposals/2026-04-25-cache-control-scope-investigation-handoff.md`
+  (analysis-only research dispatched to Architects)
+- Phase 0 SDK Compliance handoff:
+  `docs/superpowers/proposals/2026-04-25-nanoclaw-v2-phase-0-sdk-compliance-handoff.md`
+  (executor-grade plan that consumes this spec as a binding constraint)
+- Multi-environment pipeline:
+  `docs/superpowers/proposals/2026-04-25-multi-environment-architect-pipeline.md`
+  (the structural defense-in-depth)
+- Meridian `src/proxy/betas.ts` (filter, don't inject)
+- Meridian `src/proxy/query.ts:157` (`resolveSystemPrompt` — conditional preset)
+- Meridian `src/proxy/query.ts:235` (passes `betas` as SDK option)
+- Anthropic prompt-caching docs: https://docs.anthropic.com/api/prompt-caching
+- claude-agent-sdk on npm: https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk
+
+## Definition of done (for ratification)
+
+- [ ] Spec reviewed by Infra Architect (codebase implications)
+- [ ] Spec reviewed by main-ops Architect (governance integration)
+- [ ] CEO formal Approving Review under ruleset id 15502000
+- [ ] Squash-merged to main
+- [ ] OneCLI setup scripts audited for any residual `anthropic-beta`
+      injection paths (and any found are removed in the same PR)
+- [ ] Phase 0 SDK Compliance deliverable updated to cite this spec as
+      binding

--- a/docs/superpowers/specs/2026-04-25-sdk-contract-proxy-as-interop-layer.md
+++ b/docs/superpowers/specs/2026-04-25-sdk-contract-proxy-as-interop-layer.md
@@ -29,16 +29,43 @@ proxy's header are independent computations that drift over time.**
 
 ## The contract
 
+Source-grounded against OneCLI as it exists at
+`https://github.com/onecli/onecli` (clone inspected 2026-04-25).
+Citations are file paths in that repo.
+
 | Layer | Owns |
 |---|---|
-| `claude-agent-sdk` (callee) | Request body shape, `anthropic-beta` header, prompt-cache fields, OAuth bearer construction, retry semantics, SSE consumption |
-| Proxy / gateway (interop layer) | Routing, observability (logs/metrics), credential storage + retrieval, optional response caching, SSL termination, enforcing org-level allow/deny rules |
+| `claude-agent-sdk` (callee) | Request body shape, `anthropic-beta` header, prompt-cache fields, retry semantics, SSE consumption. Constructs `Authorization: Bearer <token>` when given an OAuth token directly (e.g., via `CLAUDE_CODE_OAUTH_TOKEN` env). |
+| OneCLI gateway (interop layer) | (1) Per-agent-token + per-host CONNECT policy via `PolicyEngine` (`apps/gateway/src/connect.rs:120-129`). (2) Static credential injection — for `api.anthropic.com`, sets `x-api-key: <password>` AND removes `authorization`; for all other hosts, sets `Authorization: Bearer <password>` (`apps/gateway/src/inject.rs:154-170`). (3) Generic configurable header injection via `generic`-typed secrets — operator-defined `headerName` + `valueFormat`. **This is the trap that broke us 2026-04-25.** (4) In-memory metadata cache for CONNECT resolution + injection rules (`apps/gateway/src/cache.rs`). (5) MITM TLS interception. |
 | Anthropic API (server) | Schema validation, billing, model selection, response generation |
+
+What OneCLI does NOT own (verified by source inspection):
+
+- **OAuth flows / token refresh / JWT awareness.** OneCLI's
+  `vault_credential_to_rules` (`apps/gateway/src/inject.rs:143-170`) is
+  pure static-header replacement from a stored password. No OAuth code
+  path exists in the gateway.
+- **Response-body caching.** The cache (`cache.rs`) caches CONNECT
+  resolution + injection rules only. No HTTP response bodies are
+  cached or replayed.
+- **`anthropic-beta` as a first-class concept.** Grep across
+  `apps/gateway/`, `apps/web/`, and docs returns zero matches for any
+  variant of `anthropic-beta` / `anthropic_beta`. OneCLI has no
+  built-in handling. Any `anthropic-beta` injection MUST be
+  operator-configured via a `generic` secret — and that path is the
+  bug surface this spec exists to forbid.
+- **Org-level allow/deny lists.** Policy is per-agent-token + per-host
+  pattern, not org-wide. Per-agent scoping is the only allowlist
+  surface OneCLI exposes.
 
 The SDK and the API are direct counterparties. They communicate over a
 versioned wire format that the SDK author and the API team co-evolve. A
 proxy that *modifies* that wire format puts itself in the middle of a
-contract it has no signing authority on.
+contract it has no signing authority on. **The OneCLI feature that
+broke us was `generic`-typed secrets used as a generic header injector
+for an SDK-owned header — operator misuse of a legitimate primitive,
+not a OneCLI bug.** The rule generalizes beyond OneCLI: don't use ANY
+proxy's generic-header-injection feature to inject SDK-owned headers.
 
 ## The binding rule
 


### PR DESCRIPTION
## Summary

Bundles the 2026-04-25 fleet-breakage incident-arc documentation as a single atomic review unit. **One binding spec + four execution artifacts + one operational retrospective**, all cross-referenced.

## What's in this PR

| File | Type | Status |
|---|---|---|
| `specs/2026-04-25-sdk-contract-proxy-as-interop-layer.md` | **BINDING SPEC** | NEW (this session) — needs CEO ratification |
| `plans/2026-04-25-v2-streaming-bug-onecli-fallback-patch.md` | Plan | NEW (this session) |
| `handoffs/2026-04-25-v2-claude-provider-conditional-system-prompt-refactor.md` | Handoff | NEW (this session) |
| `retros/2026-04-25-meridian-diff-and-option-d-integration-verification.md` | Retrospective | NEW (this session) |
| `proposals/2026-04-25-multi-environment-architect-pipeline.md` | Proposal | end-of-last-session |
| `proposals/2026-04-25-cache-control-scope-investigation-handoff.md` | Proposal | end-of-last-session |
| `proposals/2026-04-25-nanoclaw-v2-phase-0-sdk-compliance-handoff.md` | Proposal | end-of-last-session |
| `plans/2026-04-25-nanoclaw-v2-sdk-compliance-checklist.md` | Plan checklist | end-of-last-session |

## The headline finding (binding rule)

> **DO NOT inject SDK-owned HTTP headers (`anthropic-beta`) at proxy/gateway level.** SDK and API are direct counterparties co-evolving the wire format. A proxy that overrides the SDK's coherent header puts itself in a contract it has no signing authority on. Body-vs-header drift is structurally guaranteed over time.

Originated from 2026-04-25 root-cause: a static OneCLI `Anthropic Beta Header` secret was overriding `claude-agent-sdk` 0.2.116+'s coherent header. The body emitted `cache_control.ephemeral.scope` (gated by `prompt-caching-scope-2026-01-05`); the proxy injected a stale 3-beta string; Anthropic strict-schema-rejected. **Fix was deletion of one secret.** The whac-a-mole field-by-field debug that preceded it cost ~10 hours.

Reference implementation: Meridian (`https://github.com/rynfar/meridian`) — same architecture, contract-correct, works.

## Three new memory entries (out-of-tree, MEMORY.md indexed)

- `feedback_canonical_docs_first.md` — read canonical reference FIRST when integration breaks
- `feedback_diff_against_working_reference.md` — once reference identified, diff line-by-line; deltas ARE the bug list
- `feedback_no_proxy_header_injection.md` — never inject SDK-owned headers at proxy

## §5.5 attestation

Documentation-only PR. No code changes. Verification scope:
- All 8 files present at intended paths under `docs/superpowers/`
- Cross-references between docs validated (specs ↔ plans ↔ handoffs ↔ retros ↔ proposals)
- Three memory entries co-shipped to local memory directory + indexed in `MEMORY.md`
- No code paths modified — downstream PRs (streaming-patch, claude.ts refactor) execute the plans/handoffs in this bundle

## Test plan

- [ ] CEO reviews `specs/2026-04-25-sdk-contract-proxy-as-interop-layer.md` content
- [ ] Verify the binding rule + reference Meridian patterns are accurate
- [ ] Verify the `MUST/SHOULD/MAY` consequences for LIMITLESS deployment are right-sized
- [ ] Confirm Phase 0 + multi-env pipeline + streaming-patch + claude.ts handoff all reference the spec correctly
- [ ] Formal Approving Review under ruleset id 15502000 → squash-merge

## Downstream gates (post-merge)

1. **Spec → DR-NNN promotion** at next governance ratification cycle (binding rules deserve a DR record)
2. **Streaming-patch PR** (executes `plans/2026-04-25-v2-streaming-bug-onecli-fallback-patch.md`) — Architect dispatch when fleet operational, OR Director hand-apply with CEO ratification
3. **claude.ts refactor PR** (executes `handoffs/2026-04-25-v2-claude-provider-conditional-system-prompt-refactor.md`) — same path
4. **Multi-env pipeline spec promotion** — Infra Architect refines proposal into formal spec when fleet operational

## Related

- Topic file (CC auto-memory): `project_2026-04-25_meridian_diff_and_streaming_bug.md`
- Incident chain: PR #105 deploy 2026-04-24 07:59 UTC → fleet code 137 → ~24h debug → cache_control fix 2026-04-25 → streaming bug remains as separate narrower issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)