### PR TITLE
docs(spec): DR-003 §8.1 — operational motivation from PR-authorship friction tax

### DIFF
--- a/docs/superpowers/specs/2026-04-22-bot-feedback-loop-incident.md
+++ b/docs/superpowers/specs/2026-04-22-bot-feedback-loop-incident.md
@@ -203,6 +203,22 @@ The v1.2 governance spec (`docs/superpowers/specs/2026-04-18-agentic-sdlc-govern
 
 These can land as a single follow-on PR after this incident report ratifies. The CEO may also direct that L1 + L2 happen first (operational priority) and the governance amendments follow (codification priority), or reverse the order.
 
+### 8.1 Operational motivation for DR-003 prioritization (added 2026-04-26)
+
+Beyond the bot-feedback-loop safety motivation that originated DR-003, an additional operational value strengthens the case for early prioritization: **eliminating the Comment-review workaround tax on CC-session-originated docs/governance PRs**.
+
+Today, any PR authored from CC session uses the CEO's `gh` credentials. GitHub's API blocks "approve your own pull request" (`addPullRequestReview` returns "Can not approve your own pull request"), forcing those PRs through the Comment-review workaround + admin-bypass squash-merge under ruleset 15502000. PRs #84, #85, #94, and #109 all paid this tax. PR #105 did not because it was authored by `limitless-agent[bot]` (NanoClaw Architect) — making the CEO a non-author and unlocking §5.1 full Approving Review flow.
+
+Once DR-003 ratifies bot directive authority and grants OpenClaw Director scoped PR-authorship rights for Director-class artifacts (governance docs, retros, specs), the natural workflow shifts:
+
+| Before DR-003 | After DR-003 |
+|---|---|
+| CC session authors PR from CEO credentials → CEO is author + would-be approver → Comment-review workaround | OpenClaw Director authors PR (or NanoClaw Architect for code-touching docs) → CEO is reviewer only → §5.1 formal Approving Review |
+| Self-approval block hit; admin-bypass merge | Standard ruleset path; no admin-bypass needed |
+| Asymmetric audit trail vs bot-authored PRs | Uniform audit trail across all PR classes |
+
+This isn't a primary justification for DR-003 (the bot-feedback-loop safety case is). But it's a concrete operational dividend that reduces the friction tax on every governance/docs PR, and aligns with the broader goal of routing work to the agent best fit for it (Director writes Director-class artifacts). Memory anchor: `feedback_route_pr_authorship_to_bot.md`.
+
 ---
 
 ## 9. Open Questions


### PR DESCRIPTION
## Summary

Adds a §8.1 subsection to `docs/superpowers/specs/2026-04-22-bot-feedback-loop-incident.md` capturing an operational dividend that strengthens DR-003 prioritization beyond the original bot-feedback-loop safety motivation.

## Why

GitHub blocks self-approval at the API level. Today, any PR authored from CC session uses the CEO's `gh` credentials, making the CEO both author and would-be approver — forcing the Comment-review workaround + admin-bypass squash-merge under ruleset 15502000. PRs #84, #85, #94, and #109 all paid this tax; PR #105 didn't because it was authored by `limitless-agent[bot]`.

Once DR-003 ratifies bot directive authority and grants OpenClaw Director scoped PR-authorship rights for Director-class artifacts, this friction tax disappears and the audit trail unifies across PR classes.

## §5.5 attestation

Documentation-only PR. Single-file edit. Content provided verbatim by Director session.
- One file modified: `docs/superpowers/specs/2026-04-22-bot-feedback-loop-incident.md`
- Diff shows ONLY the new §8.1 section inserted between the §8 amendments table and §9 Open Questions (16 lines added)
- No code paths modified
- Section heading level matches sibling §9 (`### 8.1` under `## 8. Lessons → Governance Amendments Needed`)
- Markdown table parses correctly
- CI: docs-only diff, build jobs will skip per existing `detect-changes` workflow

## Authorship note

This PR is itself an instance of the workaround it documents — authored from CC session. We attempted Architect dispatch first (per the freshly-saved `feedback_route_pr_authorship_to_bot.md`), but the dispatch failed with the rate-limit-induced container death pattern documented in `feedback_rate_limit_event_is_warning.md` + the OpenClaw OAuth research response. **Action item #2 from the 2026-04-25 retro (streaming-bug patch) must ship before bypass-mode Architect dispatch becomes reliable for non-trivial work.** Falling back to CC author + Comment-review workaround tonight; routing this PR class to bots is the post-DR-003 future state.

## Refs

- PR #109 (squash `d1e3ce49`) — Meridian-diff bundle where the friction-tax pattern was last observed
- New memory entry `feedback_route_pr_authorship_to_bot.md` — indexed in `MEMORY.md` line 226
- 2026-04-25 retrospective (PR #109): `docs/superpowers/retros/2026-04-25-meridian-diff-and-option-d-integration-verification.md` — action item #2 (streaming patch) is the unblock for routing future docs PRs to Architects

## Ratification path

- Ratified via Comment-review workaround (GitHub blocks self-approval; same pattern as PRs #84/#85/#94/#109)
- CEO admin-bypass authorized under ruleset id 15502000 (RepositoryRole admin actor_id=5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)